### PR TITLE
EB-49: Website bug fixes

### DIFF
--- a/hugo/layouts/species/list.html
+++ b/hugo/layouts/species/list.html
@@ -99,6 +99,7 @@
                 selectedCards.forEach(function (card) {
                     $(card).show();
                 });
+                $("#no-filtered-card").hide();
             } else {
                 $("#no-filtered-card").show();
             }

--- a/hugo/layouts/species/list.html
+++ b/hugo/layouts/species/list.html
@@ -69,43 +69,45 @@
 
 
 <script>
-    function searchAndFilter() {
-        var searchText = $("#Search").val().toLowerCase();
+    const speciesCards = Array.from(document.querySelectorAll('.scilife-species-card'));
 
-        $(".card").hide();
+    function searchAndFilter() {
+        const searchText = $("#Search").val().toLowerCase();
+
+        $("#card-container").empty();
 
         if (searchText === "") {
-            $(".card").show();
-        } else {
-            var selectedCards = [];
-            $(".card").each(function () {
-                var $this = $(this);
-                var title = $this.find('.card-title').text().toLowerCase();
-                var cardText = $this.find('.card-text').text().toLowerCase();
-                var speciesTag = $this.find('.scilife-species-tag').text().toLowerCase();
+            speciesCards.forEach(function(card) {
+                $("#card-container").append(card.parentElement);
+            });
 
-                var conditionsArray = [
+        } else {
+            const matchedCards = speciesCards.filter(function(card) {
+                const title = $(card).find('.card-title').text().toLowerCase();
+                const cardText = $(card).find('.card-text').text().toLowerCase();
+                const speciesTag = $(card).find('.scilife-species-tag').text().toLowerCase();
+
+                const matches = [
                     title.includes(searchText),
                     cardText.includes(searchText),
                     speciesTag.includes(searchText)
                 ];
-
-                if (conditionsArray.includes(true)) {
-                    selectedCards.push(this);
-                }
+                // true if any match
+                return matches.some(Boolean);
             });
 
-            if (selectedCards.length > 0) {
-                selectedCards.forEach(function (card) {
-                    $(card).show();
-                });
-                $("#no-filtered-card").hide();
-            } else {
+            matchedCards.forEach(function(card) {
+                $("#card-container").append(card.parentElement);
+            });
+
+
+            if (matchedCards.length === 0) {
                 $("#no-filtered-card").show();
+            } else {
+                $("#no-filtered-card").hide();
             }
         }
     }
-
     $("#Search").on("input", searchAndFilter);
 </script>
 

--- a/hugo/layouts/species/species_intro.html
+++ b/hugo/layouts/species/species_intro.html
@@ -13,17 +13,33 @@
     <!-- Lineage Info -->
     <div class="row">
         <div class="col">
-            <h2>Lineage</h2>
+            <h2>Taxonomy</h2>
         </div>
     </div>
     <div class="row">
         <div class="col">
             {{ if .Params.lineage_data_path }}
                 {{ $lineage_file := (split .Params.lineage_data_path "/") }}
-                {{ $lineage_dict := index .Site.Data $lineage_file }}
+                {{ $unsorted_dict := index .Site.Data $lineage_file }}
 
-                {{ range $rank, $value := $lineage_dict }}
-                    <p> <b>{{ $rank }}:</b> {{ $value.science_name }} </p>
+                <!-- have to convert to slice to sort by key -->
+                {{ $lineage_slice := slice }}
+                {{ range $rank, $value := $unsorted_dict }}
+                    {{ $lineage_slice = $lineage_slice | append (dict "rank" $rank "value" $value) }}
+                {{ end }}
+                {{ $sorted_lineage := sort $lineage_slice "value.display_order" "desc" }}
+
+                {{ range $rank, $item := $sorted_lineage }}
+                    <p>
+                        {{ if eq $item.rank "Superkingdom" }}
+                            <b>Domain:</b>
+                        {{ else }}
+                            <b>{{ $item.rank }}:</b>
+                        {{ end }}
+
+                        <a href="{{ $item.value.ena_link }}" target="_blank">{{ $item.value.science_name }}</a>
+
+                    </p>
                 {{ end }}
 
             {{ else }}


### PR DESCRIPTION
Fixes for the following 3 issues: 
1. Species search: cards do not reorder properly when filtered by the search.
2. Species search: no results found warning does not disappear if you re-run the search i.e. delete the search that returned no results. 
3. Lineage ordering in each species introduction page is incorrect. 

**Going to merge if checks pass as still in early stages of project.**