### PR TITLE
Build genomic data in a docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,9 @@ $(DATA_DIR)/targets.mk: $(CONFIGS)
 	@CONFIG_DIR=$(CONFIG_DIR) DATA_DIR=$(DATA_DIR) $(SHELL) scripts/make_download_targets.sh $(CONFIGS) > /dev/null
 
 
-$(JBROWSE_CONFIGS): $(DATA_DIR)%.json: $(CONFIG_DIR)%.yml
-	$(SHELL) scripts/generate_jbrowse_config.sh $@ $<
+$(JBROWSE_CONFIGS): $(DATA_DIR)/%.json: $(CONFIG_DIR)/%.yml
+	@echo "Generating JBrowse configuration for $(*D)"
+	@$(SHELL) scripts/generate_jbrowse_config.sh $@ $<
 
 
 $(FASTA_INDICES): %.fai: %

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ debug:
 .PHONY: jbrowse-config
 jbrowse-config: $(JBROWSE_CONFIGS);
 	$(call log_info,'Generated JBrowse configuration in directories')
-	@printf "  \U1F4C1 %s\n" $(JBROWSE_CONFIGS:/config.json=)
+	@printf "  - %s\n" $(JBROWSE_CONFIGS:/config.json=)
 
 
 .PHONY: download

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,15 @@ MAKEFLAGS += -r
 
 CONFIG_DIR=config
 DATA_DIR=data
-CONFIGS = $(shell find $(CONFIG_DIR) -type f -name 'config.yml')
+
+# To restrict operations on a subset of available species, specify
+# them as a comma separated list on the command line (after
+# invalidating `targets.mk` if necessary)
+# Example:
+#   rm data/targets.mk && make SPECIES=linum_tenue,clupea_harengus build
+SPECIES=$(SPECIES:%:{%})
+
+CONFIGS = $(shell find $(CONFIG_DIR)/$(SPECIES) -type f -name 'config.yml')
 JBROWSE_CONFIGS = $(subst $(CONFIG_DIR)/,$(DATA_DIR)/,$(CONFIGS:.yml=.json))
 
 # Defines the DOWNLOAD_TARGETS variable

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ MAKEFLAGS += -r
 
 CONFIG_DIR=config
 DATA_DIR=data
+INSTALL_DIR=hugo/static
 
 # To restrict operations to a subset of species, assign them as a
 # comma-separated list to the SPECIES variable. Example:
@@ -93,12 +94,12 @@ compress: $(LOCAL_FILES);
 # Copy data and configuration to hugo static folder
 .PHONY: install
 install:
-	@cp --parents -t hugo/static $(LOCAL_FILES) $(GFF_INDICES) $(FASTA_INDICES) $(JBROWSE_CONFIGS)
+	@cp --parents -t $(INSTALL_DIR) $(LOCAL_FILES) $(GFF_INDICES) $(FASTA_INDICES) $(JBROWSE_CONFIGS)
 
 # Remove JBrowse data and configuration from hugo static folder
    .PHONY: uninstall
 uninstall:
-	rm -r hugo/static/data
+	rm -rf $(INSTALL_DIR)/$(DATA_DIR)
 
 
 .PHONY: index-fasta

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,12 @@ ifneq ($(GFF_INDICES),)
 	@printf '  - %s\n' $(GFF_INDICES)
 endif
 
-$(DATA_DIR)/targets.mk: $(CONFIGS)
+
+ifeq ($(MAKE_RESTARTS),)
+$(DATA_DIR)/targets.mk: FORCE
 	@CONFIG_DIR=$(CONFIG_DIR) DATA_DIR=$(DATA_DIR) $(SHELL) scripts/make_download_targets.sh $(CONFIGS) > /dev/null
+FORCE:;
+endif
 
 
 $(JBROWSE_CONFIGS): $(DATA_DIR)/%.json: $(CONFIG_DIR)/%.yml

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,10 @@ MAKEFLAGS += -r
 CONFIG_DIR=config
 DATA_DIR=data
 
-# To restrict operations on a subset of available species, specify
-# them as a comma separated list on the command line (after
-# invalidating `targets.mk` if necessary)
-# Example:
-#   rm data/targets.mk && make SPECIES=linum_tenue,clupea_harengus build
+# To restrict operations to a subset of species, assign them as a
+# comma-separated list to the SPECIES variable. Example:
+#
+#     make SPECIES=linum_tenue,clupea_harengus build
 SPECIES=$(SPECIES:%:{%})
 
 CONFIGS = $(shell find $(CONFIG_DIR)/$(SPECIES) -type f -name 'config.yml')

--- a/data.dockerfile
+++ b/data.dockerfile
@@ -4,7 +4,6 @@ VOLUME /swedgene/data
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq \
     && chmod +x /usr/bin/yq
 RUN npm install -g @jbrowse/cli
-RUN git init -q
 # COPY config config fails
 COPY config species
 COPY scripts scripts/

--- a/data.dockerfile
+++ b/data.dockerfile
@@ -1,7 +1,11 @@
 FROM node:22.2.0
 WORKDIR /swedgene
 VOLUME /swedgene/data
-RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq \
+RUN curl -fsSL https://github.com/samtools/samtools/releases/download/1.20/samtools-1.20.tar.bz2 \
+    | tar -C /tmp -xjf-  \
+    && cd /tmp/samtools-1.20 && ./configure && make && make install \
+    && cd - && rm -rf /tmp/samtools-1.20
+RUN curl -fsSL --output /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
     && chmod +x /usr/bin/yq
 RUN npm install -g @jbrowse/cli
 # COPY config config fails

--- a/data.dockerfile
+++ b/data.dockerfile
@@ -1,1 +1,12 @@
-# placeholder for building dataset image 
+FROM node:22.2.0
+WORKDIR /swedgene
+VOLUME /swedgene/data
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq \
+    && chmod +x /usr/bin/yq
+RUN npm install -g @jbrowse/cli
+RUN git init -q
+# COPY config config fails
+COPY config species
+COPY scripts scripts/
+COPY Makefile .
+CMD ["make", "CONFIG_DIR=species", "debug"]

--- a/data.dockerfile
+++ b/data.dockerfile
@@ -8,8 +8,11 @@ RUN curl -fsSL https://github.com/samtools/samtools/releases/download/1.20/samto
 RUN curl -fsSL --output /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
     && chmod +x /usr/bin/yq
 RUN npm install -g @jbrowse/cli
-# COPY config config fails
 COPY config config
 COPY scripts scripts
 COPY Makefile .
+ARG SWG_UID=1000
+ARG SWG_GID=1000
+RUN groupmod -g ${SWG_GID} node && usermod -u ${SWG_UID} -g ${SWG_GID} node
+USER node
 CMD ["make", "debug"]

--- a/data.dockerfile
+++ b/data.dockerfile
@@ -3,7 +3,7 @@ WORKDIR /swedgene
 VOLUME /swedgene/data
 RUN curl -fsSL https://github.com/samtools/samtools/releases/download/1.20/samtools-1.20.tar.bz2 \
     | tar -C /tmp -xjf-  \
-    && cd /tmp/samtools-1.20 && ./configure && make && make install \
+    && cd /tmp/samtools-1.20 && ./configure && make all all-htslib && make install install-htslib \
     && cd - && rm -rf /tmp/samtools-1.20
 RUN curl -fsSL --output /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
     && chmod +x /usr/bin/yq

--- a/data.dockerfile
+++ b/data.dockerfile
@@ -5,7 +5,7 @@ RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
     && chmod +x /usr/bin/yq
 RUN npm install -g @jbrowse/cli
 # COPY config config fails
-COPY config species
-COPY scripts scripts/
+COPY config config
+COPY scripts scripts
 COPY Makefile .
-CMD ["make", "CONFIG_DIR=species", "debug"]
+CMD ["make", "debug"]

--- a/docker.mk
+++ b/docker.mk
@@ -1,0 +1,5 @@
+.PHONY: build
+build:
+	docker run -u $$(id -u):$$(id -g) -v "$$(pwd)/data":/swedgene/data -v "$$(pwd)/Makefile:/swedgene/Makefile" swedgene-data make build
+
+

--- a/docker.mk
+++ b/docker.mk
@@ -1,5 +1,0 @@
-.PHONY: build
-build:
-	docker run -u $$(id -u):$$(id -g) -v "$$(pwd)/data":/swedgene/data -v "$$(pwd)/Makefile:/swedgene/Makefile" swedgene-data make build
-
-

--- a/scripts/dockerbuild.sh
+++ b/scripts/dockerbuild.sh
@@ -1,0 +1,12 @@
+# Helper script to build Docker images
+
+
+if [[ -z "$1" || "$1" == "data" ]];
+then
+    SWG_BUILD_ARGS=("--build-arg" "SWG_UID=${SWG_UID:-$(id -u)}" "--build-arg" "SWG_GID=${SWG_GID:-$(id -g)}")
+    docker build "${SWG_BUILD_ARGS[@]}" -t swedgene-data -f data.dockerfile . && exit 0
+fi
+echo "Usage: ./scripts/dockerbuild.sh [data]" && exit 1
+
+
+

--- a/scripts/dockermake.sh
+++ b/scripts/dockermake.sh
@@ -1,0 +1,3 @@
+# Run `make` in a Docker container
+CWD="$(pwd)"
+docker run -u "$(id -u):$(id -g)" -v "$CWD/${DATA_DIR:-data}:/swedgene/data" -v "$CWD/Makefile:/swedgene/Makefile" swedgene-data make "$@"

--- a/scripts/dockermake.sh
+++ b/scripts/dockermake.sh
@@ -1,4 +1,13 @@
 # Run `make` in a Docker container
+#
+# The environment variables SWG_UID and SWG_GID can be used to run the
+# container as a specific user and group. By default, the effective
+# user and group id of the host are used.
+
 CWD="$(pwd)"
 mkdir -p "${DATA_DIR:=data}"
-docker run -u "$(id -u):$(id -g)" -v "$CWD/${DATA_DIR}:/swedgene/data" -v "$CWD/Makefile:/swedgene/Makefile" swedgene-data make "$@"
+if [[ -n $SWG_UID || -n $SWG_GID ]];
+then
+    SWG_DOCKER_USER=("-u" "${SWG_UID:-$(id -u)}:${SWG_GID:-$(id -g)}")
+fi
+docker run "${SWG_DOCKER_USER[@]}" -v "$CWD/${DATA_DIR}:/swedgene/data" -v "$CWD/Makefile:/swedgene/Makefile" swedgene-data make "$@"

--- a/scripts/dockermake.sh
+++ b/scripts/dockermake.sh
@@ -1,3 +1,4 @@
 # Run `make` in a Docker container
 CWD="$(pwd)"
-docker run -u "$(id -u):$(id -g)" -v "$CWD/${DATA_DIR:-data}:/swedgene/data" -v "$CWD/Makefile:/swedgene/Makefile" swedgene-data make "$@"
+mkdir -p "${DATA_DIR:=data}"
+docker run -u "$(id -u):$(id -g)" -v "$CWD/${DATA_DIR}:/swedgene/data" -v "$CWD/Makefile:/swedgene/Makefile" swedgene-data make "$@"

--- a/scripts/dockermake.sh
+++ b/scripts/dockermake.sh
@@ -5,9 +5,13 @@
 # user and group id of the host are used.
 
 CWD="$(pwd)"
-mkdir -p "${DATA_DIR:=data}"
+mkdir -p "${DATA_DIR:=data}" "${INSTALL_DIR:=hugo/static}"
 if [[ -n $SWG_UID || -n $SWG_GID ]];
 then
     SWG_DOCKER_USER=("-u" "${SWG_UID:-$(id -u)}:${SWG_GID:-$(id -g)}")
 fi
-docker run "${SWG_DOCKER_USER[@]}" -v "$CWD/${DATA_DIR}:/swedgene/data" -v "$CWD/Makefile:/swedgene/Makefile" swedgene-data make "$@"
+docker run "${SWG_DOCKER_USER[@]}" \
+       -v "$CWD/${DATA_DIR}:/swedgene/data" \
+       -v "$CWD/Makefile:/swedgene/Makefile" \
+       -v "$CWD/${INSTALL_DIR}:/swedgene/hugo/static" \
+       swedgene-data make "$@"

--- a/scripts/generate_jbrowse_config.sh
+++ b/scripts/generate_jbrowse_config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-BASE_DIR="$(git rev-parse --show-toplevel)"
-source "$BASE_DIR"/scripts/utils.sh
+SRC_DIR="${BASH_SOURCE%/*}"
+source "$SRC_DIR/utils.sh"
 
 TARGET="$1"
 CONFIG="$2"

--- a/scripts/make_download_targets.sh
+++ b/scripts/make_download_targets.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
-# Generate a makefile defining data files to download
+# Generate a makefile initializing the DOWNLOAD_TARGETS variable.
 
-# Root of the project, in which Makefile and include.mk reside
-BASE_DIR="$(git rev-parse --show-toplevel)"
+# The value of DOWNLOAD_TARGETS is a space-separated list of files
+# that should be downloaded for local processing. As a side effect,
+# the URL from which target <species>/<filename> should be fectched is
+# stored in the file $DATA_DIR/.downloads/<species>/<file>.
+
+SRC_DIR="${BASH_SOURCE%/*}"
+source "$SRC_DIR/utils.sh"
 
 CACHE_DIR="${DATA_DIR:=data}/.downloads"
-
-source "$BASE_DIR/scripts/utils.sh"
 MAKEFILE="$DATA_DIR/targets.mk"
 DOWNLOAD_EXTENSIONS=(".fna" ".gff")
 


### PR DESCRIPTION
This pull request introduces:
- A Dockerfile `data.dockerfile` to build a `swedgene-data` image based on `node` containing the `samtools` and `htslib` dependencies needed to prepare JBrowse data
- A`scripts/dockermake.sh` helper script that spins up a container with the host `data/` directory and `Makefile` mounted

I also reintroduced the ability to limit species to consider. The following example summarizes the new workflow:
```bash
docker build -f data.dockerfile -t swedgene-data .
# If you want to restrict the species, make sure to invalidate the download targets
rm -f data/targets.mk
# Arguments to the helper script are forwarded to make 
./scripts/dockermake.sh SPECIES=clupea_harengus build
```
I leave the draft status because it is still a bit rough, but wanted to give you a chance to play with it while I am away next week. 
Cheers :)