### PR TITLE
EB-80: Add contact form that sends email to dsn email

### DIFF
--- a/hugo/content/contact/_index.md
+++ b/hugo/content/contact/_index.md
@@ -2,6 +2,6 @@
 title: Contact
 ---
 
-[Some intro text for the contact form page]
+We welcome all questions and suggestions regarding the genome portal. Please feel free to send an email to the team behind the portal at [dsn-eb@scilifelab.se](mailto:dsn-eb@scilifelab.se) or fill in the contact form below and we'll get back to you as soon as possible.
 
-### Contact form
+If you would like to get in contact due to an issue with the website and have a GitHub account you are also very welcome to [create an issue on the projects repository](https://github.com/ScilifelabDataCentre/swedgene/issues/new), but it is of course fine to use our email or the form below.

--- a/hugo/content/contact/_index.md
+++ b/hugo/content/contact/_index.md
@@ -5,3 +5,18 @@ title: Contact
 We welcome all questions and suggestions regarding the genome portal. Please feel free to send an email to the team behind the portal at [dsn-eb@scilifelab.se](mailto:dsn-eb@scilifelab.se) or fill in the contact form below and we'll get back to you as soon as possible.
 
 If you would like to get in contact due to an issue with the website and have a GitHub account you are also very welcome to [create an issue on the projects repository](https://github.com/ScilifelabDataCentre/swedgene/issues/new), but it is of course fine to use our email or the form below.
+
+{{< contact_form >}}
+
+### Personal data policy
+
+The personal data you provide in this form including your name and email address,
+will be used solely to address your questions/suggestions regarding the Genome Portal.
+
+This Portal is run by the SciLifeLab Data Centre and the following parties
+will have access to processing your personal data: SciLifeLab Data Centre, Uppsala University.
+
+The information you provide will be processed for research purposes, i.e. using the lawful basis of public interest and in accordance with Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016, the General Data Protection Regulation.
+
+Your personal data will be deleted when no longer needed, or when stipulated by the archival rules for the university as a government authority.
+If you want to update or remove your personal data please contact the controller SciLifeLab Data Centre at Uppsala University: <a href="mailto:dsn-eb@scilifelab.se">dsn-eb@scilifelab.se</a>.

--- a/hugo/content/privacy/_index.md
+++ b/hugo/content/privacy/_index.md
@@ -6,13 +6,12 @@ title: Privacy Policy
 
 1. Does this also need to be provided in Swedish?
 2. Someone other than Rory needs to check the content/wording etc...
-3. Add contact information
 
-## Overview
+### Privacy Policy Overview
 
-This site is operated by SciLifeLab and this page is used to inform website visitors regarding our data processing and privacy policy. If you choose to use our **Service**, then your personal data will be processed in accordance with this policy.
+This site is operated by SciLifeLab Data Centre and this page is used to inform website visitors regarding our data processing and privacy policy. If you choose to use our **Service**, then your personal data will be processed in accordance with this policy.
 
-## Log Data
+### Log Data
 
 We want to inform you that whenever you visit our **Service**, we collect the information that your browser sends to us, which is called 'log data'. Log data may include: the website that you visited us from, the parts of our **Service** you visit, the date and duration of your visit, your anonymised IP address, information from the device that you used during your visit (device type, operating system, screen resolution, language, country you are located in, and web browser type), and more. We process this usage data in Matomo Analytics (hosted on SciLifeLab servers and operated solely by SciLifeLab) for statistical purposes, to improve our **Service**, and to recognise and stop any misuse.
 
@@ -23,19 +22,17 @@ We want to inform you that whenever you visit our **Service**, we collect the in
 The personal information that we collect is used for providing and improving the **Service**.
 We will not use or share your information with anyone except as described in this policy. All collected personal information will be processed for research purposes, i.e. using the lawful basis of public interest and in accordance with Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016, the General Data Protection Regulation.
 
-## Links to Other Sites
+### Links to Other Sites
 
 Our **Service** may contain links to other sites. If you click on a third-party link, you will be directed to that site. Note that these external sites are not operated by us. Therefore, we strongly advise you to review the privacy policy of these websites. We have no control over, and assume no responsibility for, the content, privacy policies, or practices of any third-party sites or services.
 
-## Changes to This Privacy Policy
+### Changes to This Privacy Policy
 
 We may update our privacy policy from time to time.
 Thus, we advise you to review this page periodically for any changes.
 We will notify you of any changes by posting the new privacy policy on this page.
 These changes posted on this page are effective immediately.
 
-## Contact Us
+### Contact Us
 
-If you have any questions or suggestions about our privacy policy, do not hesitate to contact us.
-
-TODO - add our contact information here once ready.
+If you have any questions or suggestions about our privacy policy, do not hesitate to <a href="/contact" target="_blank">contact us</a>.

--- a/hugo/layouts/_default/list.html
+++ b/hugo/layouts/_default/list.html
@@ -1,5 +1,11 @@
 {{ define "main" }}
 
-{{ .Content }}
+<div class="container mt-3">
+    <div class="row">
+        <div class="col scilife-subsection mt-3">
+            {{ .Content }}
+        </div>
+    </div>
+</div>
 
 {{ end }}

--- a/hugo/layouts/_default/single.html
+++ b/hugo/layouts/_default/single.html
@@ -1,5 +1,11 @@
 {{ define "main" }}
 
-{{ .Content }}
+<div class="container mt-3">
+    <div class="row">
+        <div class="col scilife-subsection mt-3">
+            {{ .Content }}
+        </div>
+    </div>
+</div>
 
 {{ end }}

--- a/hugo/layouts/about/list.html
+++ b/hugo/layouts/about/list.html
@@ -1,13 +1,20 @@
 {{ define "main" }}
 
-<div class="alert alert-primary scilife-alert" role="alert">
-    <i class="bi bi-info-circle">
-        Denna sida finns också på svenska,
-        <a href="/about/sv">klicka här för att komma dit.</a>
-    </i>
+<div class="container mt-3">
+    <div class="row">
+        <div class="alert alert-primary scilife-alert" role="alert">
+            <i class="bi bi-info-circle">
+                Denna sida finns också på svenska,
+                <a href="/about/sv">klicka här för att komma dit.</a>
+            </i>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col scilife-subsection mt-3">
+            {{ .Content }}
+        </div>
+    </div>
 </div>
-
-{{ .Content }}
-
 
 {{ end }}

--- a/hugo/layouts/about/single.html
+++ b/hugo/layouts/about/single.html
@@ -1,12 +1,20 @@
 {{ define "main" }}
 
-<div class="alert alert-primary scilife-alert" role="alert">
-    <i class="bi bi-info-circle">
-        This page also exists in english,
-        <a href="/about">click here to go to this page.</a>
-    </i>
-</div>
+<div class="container mt-3">
+    <div class="row">
+        <div class="alert alert-primary scilife-alert" role="alert">
+            <i class="bi bi-info-circle">
+                This page also exists in english,
+                <a href="/about">click here to go to this page.</a>
+            </i>
+        </div>
+    </div>
 
-{{ .Content }}
+    <div class="row">
+        <div class="col scilife-subsection mt-3">
+            {{ .Content }}
+        </div>
+    </div>
+</div>
 
 {{ end }}

--- a/hugo/layouts/contact/list.html
+++ b/hugo/layouts/contact/list.html
@@ -16,7 +16,20 @@
     <div class="row">
         <div class="col scilife-subsection mt-3">
             <h3>Personal data policy</h3>
-            <p>TODO</p>
+            <p>
+                The personal data you provide in this form including your name and email address,
+                will be used to process your question/suggestion for the Genome Portal.
+                This portal is run by the SciLifeLab Data Centre and the following parties
+                will have access to processing your personal data: SciLifeLab Data Centre, Uppsala University.
+            </p>
+            <p>
+                The information you provide will be processed for research purposes, i.e. using the lawful basis of public interest and in accordance with Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016, the General Data Protection Regulation.
+            </p>
+            <p>
+                Your personal data will be deleted when no longer needed, or when stipulated by the archival rules for the university as a government authority.
+                If you want to update or remove your personal data please contact the controller SciLifeLab Data Centre at Uppsala University:
+                <a href="mailto:dsn-eb@scilifelab.se">dsn-eb@scilifelab.se</a>.
+            </p>
         </div>
     </div>
 

--- a/hugo/layouts/contact/list.html
+++ b/hugo/layouts/contact/list.html
@@ -1,7 +1,30 @@
 {{ define "main" }}
 
-{{ .Content }}
+<div class="container mt-3">
+    <div class="row">
+        <div class="col scilife-subsection mt-3">
+            {{ .Content }}
+        </div>
+    </div>
 
-[Contact form html code here]
+
+    <div class="row scilife-subsection">
+        {{ partial "contact_form.html" .}}
+    </div>
+
+
+    <div class="row">
+        <div class="col scilife-subsection mt-3">
+            <h3>Personal data policy</h3>
+            <p>TODO</p>
+        </div>
+    </div>
+
+
+
+</div>
+
+
+
 
 {{ end }}

--- a/hugo/layouts/contact/list.html
+++ b/hugo/layouts/contact/list.html
@@ -6,38 +6,6 @@
             {{ .Content }}
         </div>
     </div>
-
-
-    <div class="row scilife-subsection">
-        {{ partial "contact_form.html" .}}
-    </div>
-
-
-    <div class="row">
-        <div class="col scilife-subsection mt-3">
-            <h3>Personal data policy</h3>
-            <p>
-                The personal data you provide in this form including your name and email address,
-                will be used to process your question/suggestion for the Genome Portal.
-                This portal is run by the SciLifeLab Data Centre and the following parties
-                will have access to processing your personal data: SciLifeLab Data Centre, Uppsala University.
-            </p>
-            <p>
-                The information you provide will be processed for research purposes, i.e. using the lawful basis of public interest and in accordance with Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016, the General Data Protection Regulation.
-            </p>
-            <p>
-                Your personal data will be deleted when no longer needed, or when stipulated by the archival rules for the university as a government authority.
-                If you want to update or remove your personal data please contact the controller SciLifeLab Data Centre at Uppsala University:
-                <a href="mailto:dsn-eb@scilifelab.se">dsn-eb@scilifelab.se</a>.
-            </p>
-        </div>
-    </div>
-
-
-
 </div>
-
-
-
 
 {{ end }}

--- a/hugo/layouts/partials/contact_form.html
+++ b/hugo/layouts/partials/contact_form.html
@@ -1,0 +1,72 @@
+<form class="needs-validation" novalidate method="POST" accept-charset="utf-8"
+    action="https://forms.dc.scilifelab.se/api/v1/form/-FAZyGOzesRv5i0B/incoming">
+
+    <h3>Contact Form</h3>
+
+    <div class="my-3">
+        <label for="nameInput" class="form-label">Your name*</label>
+        <input type="text" class="form-control" id="nameInput" placeholder="first name last name" required>
+    </div>
+
+    <div class="mb-3">
+        <label for="emailInput" class="form-label">Email address</label>
+        <input type="email" class="form-control" id="emailInput" placeholder="name@example.com"
+            aria-describedby="emailHelp">
+        <div id="emailHelp" class="form-text">
+            Add your email if you would like to be recieve a response about this matter.
+        </div>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label">
+            Select the reason that best describes why you got in contact with us.*
+        </label>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault1" value="questionAboutPortal" required aria-label="Question about the Portal">
+            <label class="form-check-label" for="flexRadioDefault1">
+                Question about the Portal
+            </label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault2" value="reportAnIssue" aria-label="Report an issue">
+            <label class="form-check-label" for="flexRadioDefault2">
+                Report an issue
+            </label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault3" value="suggestAnImprovement" aria-label="Suggest an improvement">
+            <label class="form-check-label" for="flexRadioDefault3">
+                Suggest an improvement
+            </label>
+        </div>
+        <div class="form-check">
+            <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault4" value="other" aria-label="Other">
+            <label class="form-check-label" for="flexRadioDefault4">
+                Other
+            </label>
+        </div>
+    </div>
+
+    <div class="mb-3">
+        <label for="textareaInput" class="form-label" style="display: block;">
+            Please describe your question or suggestion here (max 1000 characters)*
+        </label>
+        <textarea class="form-control" id="textareaInput" aria-label="text input"
+            maxlength="1000" rows="8" required style="display: block; width: 100%;"></textarea>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Submit the form</button>
+</form>
+
+
+<script>
+    var form = document.querySelector('.needs-validation');
+    form.addEventListener('submit', function (event) {
+        if (form.checkValidity() === false) {
+            event.preventDefault();
+            alert("Please fill out all required fields");
+            event.stopPropagation();
+            form.classList.add('was-validated');
+        }
+    });
+</script>

--- a/hugo/layouts/partials/contact_form.html
+++ b/hugo/layouts/partials/contact_form.html
@@ -1,4 +1,4 @@
-<form class="needs-validation" novalidate method="POST" accept-charset="utf-8"
+<form class="needs-validation" novalidate method="POST" accept-charset="utf-8" id="contactForm"
     action="https://forms.dc.scilifelab.se/api/v1/form/-FAZyGOzesRv5i0B/incoming">
 
     <h3>Contact Form</h3>
@@ -13,34 +13,38 @@
         <input type="email" class="form-control" name="email" id="emailInput" placeholder="name@example.com"
             aria-describedby="emailHelp">
         <div id="emailHelp" class="form-text">
-            Add your email if you would like to be recieve a response about this matter.
+            Add your email address if you would like to be receive a response regarding this matter.
         </div>
     </div>
 
     <div class="mb-3">
         <label class="form-label">
-            Select the reason that best describes why you got in contact with us.*
+            Select the reason that best describes why you're getting in contact with us.*
         </label>
         <div class="form-check">
-            <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault1" value="questionAboutPortal" required aria-label="Question about the Portal">
+            <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault1"
+                value="questionAboutPortal" required aria-label="Question about the Portal">
             <label class="form-check-label" for="flexRadioDefault1">
                 Question about the Portal
             </label>
         </div>
         <div class="form-check">
-            <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault2" value="reportAnIssue" aria-label="Report an issue">
+            <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault2"
+                value="reportAnIssue" aria-label="Report an issue">
             <label class="form-check-label" for="flexRadioDefault2">
                 Report an issue
             </label>
         </div>
         <div class="form-check">
-            <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault3" value="suggestAnImprovement" aria-label="Suggest an improvement">
+            <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault3"
+                value="suggestAnImprovement" aria-label="Suggest an improvement">
             <label class="form-check-label" for="flexRadioDefault3">
                 Suggest an improvement
             </label>
         </div>
         <div class="form-check">
-            <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault4" value="other" aria-label="Other">
+            <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault4" value="other"
+                aria-label="Other">
             <label class="form-check-label" for="flexRadioDefault4">
                 Other
             </label>
@@ -49,36 +53,63 @@
 
     <div class="mb-3">
         <label for="textareaInput" class="form-label" style="display: block;">
-            Please describe your question or suggestion here (max 1000 characters)*
+            Please describe your question or suggestion below (max 1000 characters)*
         </label>
-        <textarea class="form-control" id="textareaInput" name="description" aria-label="text input"
-            maxlength="1000" rows="8" required style="display: block; width: 100%;"></textarea>
+        <textarea class="form-control" id="textareaInput" name="description" aria-label="text input" maxlength="1000"
+            rows="8" required style="display: block; width: 100%;"></textarea>
     </div>
 
     <div id="formAlert" class="alert alert-danger mb-3" role="alert" style="display: none;">
-        Please fill out all required fields using appropriate values.
+        Please fill out all the required fields using appropriate values.
     </div>
 
-    <button type="submit" class="btn btn-primary">Submit the form</button>
+    <div class="mb-3">
+        <div class="g-recaptcha" id="recaptcha-widget" data-sitekey="6LfLRQMqAAAAACSectjtigWkNvif1G2J8EFlj1nV"></div>
+    </div>
 
+    <div id="reCAPTCHAAlert" class="alert alert-danger mb-3" role="alert" style="display: none;">
+        Please verify you're not a robot in order to submit the form.
+    </div>
 
+    <button type="submit" class="btn btn-primary">Submit</button>
 
 </form>
 
+<script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script>
+
 
 <script>
-    var form = document.querySelector('.needs-validation');
-    var formAlert = document.getElementById('formAlert');
+    const form = document.querySelector('.needs-validation');
+    const formAlert = document.getElementById('formAlert');
+    const reCAPTCHAAlert = document.getElementById('reCAPTCHAAlert');
 
     form.addEventListener('submit', function (event) {
-        if (form.checkValidity() === false) {
+        const isFormValid = form.checkValidity();
+        const recaptchaValue = $("#g-recaptcha-response").val();
+
+        if (!isFormValid || recaptchaValue === "") {
             event.preventDefault();
             event.stopPropagation();
-            form.classList.add('was-validated');
 
-            formAlert.style.display = 'block';
+            if (!isFormValid) {
+                form.classList.add('was-validated');
+                formAlert.style.display = 'block';
+            } else {
+                formAlert.style.display = 'none';
+            }
+
+            if (recaptchaValue === "") {
+                reCAPTCHAAlert.style.display = 'block';
+            } else {
+                reCAPTCHAAlert.style.display = 'none';
+            }
+            grecaptcha.reset();
+
         } else {
             formAlert.style.display = 'none';
+            reCAPTCHAAlert.style.display = 'none';
+            // Form submission occurs now
         }
     });
+
 </script>

--- a/hugo/layouts/partials/contact_form.html
+++ b/hugo/layouts/partials/contact_form.html
@@ -5,12 +5,12 @@
 
     <div class="my-3">
         <label for="nameInput" class="form-label">Your name*</label>
-        <input type="text" class="form-control" id="nameInput" placeholder="first name last name" required>
+        <input type="text" class="form-control" name="name" id="nameInput" placeholder="first name last name" required>
     </div>
 
     <div class="mb-3">
         <label for="emailInput" class="form-label">Email address</label>
-        <input type="email" class="form-control" id="emailInput" placeholder="name@example.com"
+        <input type="email" class="form-control" name="email" id="emailInput" placeholder="name@example.com"
             aria-describedby="emailHelp">
         <div id="emailHelp" class="form-text">
             Add your email if you would like to be recieve a response about this matter.
@@ -51,22 +51,34 @@
         <label for="textareaInput" class="form-label" style="display: block;">
             Please describe your question or suggestion here (max 1000 characters)*
         </label>
-        <textarea class="form-control" id="textareaInput" aria-label="text input"
+        <textarea class="form-control" id="textareaInput" name="description" aria-label="text input"
             maxlength="1000" rows="8" required style="display: block; width: 100%;"></textarea>
     </div>
 
+    <div id="formAlert" class="alert alert-danger mb-3" role="alert" style="display: none;">
+        Please fill out all required fields using appropriate values.
+    </div>
+
     <button type="submit" class="btn btn-primary">Submit the form</button>
+
+
+
 </form>
 
 
 <script>
     var form = document.querySelector('.needs-validation');
+    var formAlert = document.getElementById('formAlert');
+
     form.addEventListener('submit', function (event) {
         if (form.checkValidity() === false) {
             event.preventDefault();
-            alert("Please fill out all required fields");
             event.stopPropagation();
             form.classList.add('was-validated');
+
+            formAlert.style.display = 'block';
+        } else {
+            formAlert.style.display = 'none';
         }
     });
 </script>

--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -18,15 +18,20 @@
             <div class="col-md-5">
                 <ul class="list-unstyled">
                     <li>
-                        <p>This site is developed and operated by the SciLifeLab Data Centre.
-                            This resource is free to use for all.
-                            [TODO something here about who can add data].
-                            The code used to create this site is <a
-                                href="https://github.com/ScilifelabDataCentre/swedgene/">available on GitHub</a>.
+                        <p> This site is developed and operated by the SciLifeLab Data Centre and is
+                            free to use for all.
+
+                            If you have a genome project you would like to add to this site, please visit the
+                            <a href="/add_genome">Add a genome project</a> page for further instructions.
+
+                            The code used to create this site is
+                            <a href="https://github.com/ScilifelabDataCentre/swedgene/" target="_blank">
+                                available on GitHub
+                            </a>.
                         </p>
                     </li>
                     <li>
-                        <p> Please email <a href="TODO">TODO@TODO.se</a> with questions </p>
+                        <p> Please email <a href="mailto:dsn-eb@scilifelab.se">dsn-eb@scilifelab.se</a> with questions.</p>
                     </li>
 
                 </ul>

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -38,4 +38,14 @@
         <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
         <script src="https://unpkg.com/@jbrowse/react-app/dist/react-app.umd.development.js" crossorigin></script>
     {{ end }}
+
+    {{ if eq .Type "contact" }}
+        <script type="text/javascript">
+            var onloadCallback = function() {
+            grecaptcha.render(id="recaptcha-widget", {
+                'sitekey' : '6LfLRQMqAAAAACSectjtigWkNvif1G2J8EFlj1nV'
+            });
+            };
+        </script>
+    {{ end }}
 </head>

--- a/hugo/layouts/shortcodes/contact_form.html
+++ b/hugo/layouts/shortcodes/contact_form.html
@@ -9,17 +9,17 @@
     </div>
 
     <div class="mb-3">
-        <label for="emailInput" class="form-label">Email address</label>
+        <label for="emailInput" class="form-label">Email address (optional)</label>
         <input type="email" class="form-control" name="email" id="emailInput" placeholder="name@example.com"
             aria-describedby="emailHelp">
         <div id="emailHelp" class="form-text">
-            Add your email address if you would like to be receive a response regarding this matter.
+            Add your email address if you would like to receive a response from us regarding this matter.
         </div>
     </div>
 
     <div class="mb-3">
         <label class="form-label">
-            Select the reason that best describes why you're getting in contact with us.*
+            Please select the reason that best describes why you're getting in contact with us.*
         </label>
         <div class="form-check">
             <input class="form-check-input" type="radio" name="contactReason" id="flexRadioDefault1"
@@ -71,7 +71,7 @@
         Please verify you're not a robot in order to submit the form.
     </div>
 
-    <button type="submit" class="btn btn-primary">Submit</button>
+    <button type="submit" class="btn btn-primary mb-3">Submit</button>
 
 </form>
 

--- a/hugo/static/css/styles.css
+++ b/hugo/static/css/styles.css
@@ -283,9 +283,8 @@ iframe#matoOpOut {
 }
 
 /* Styles for different screen sizes */
-@media (max-width: 412px)  { iframe#matoOpOut { height: 25vh; } }
-@media (max-width: 479px)  { iframe#matoOpOut { height: 20vh; } }
-@media (min-width: 480px)  { iframe#matoOpOut { height: 14vh; } }
-@media (min-width: 600px)  { iframe#matoOpOut { height: 13vh; } }
-@media (min-width: 768px)  { iframe#matoOpOut { height: 12vh; } }
-@media (min-width: 1024px) { iframe#matoOpOut { height: 10vh; } }
+@media (max-width: 360px)  { iframe#matoOpOut { height: 50vh; } }
+@media (min-width: 361px)  { iframe#matoOpOut { height: 25vh; } }
+@media (min-width: 492px)  { iframe#matoOpOut { height: 20vh; } }
+@media (min-width: 768px)  { iframe#matoOpOut { height: 15vh; } }
+@media (min-width: 1024px) { iframe#matoOpOut { height: 14vh; } }


### PR DESCRIPTION
Contact page now has a contact form using [Scilifelab's in house form manager](https://github.com/ScilifelabDataCentre/form-manager/tree/main). Form has reCAPTCHA v2 included. 

Some minor changes to the non-species related pages to make styling consistent or add some text as well. 

(Will merge myself as early stages of project)