### PR TITLE
EB-84: Populate "add-species" markdown pages

### DIFF
--- a/.github/.markdownlint.yaml
+++ b/.github/.markdownlint.yaml
@@ -1,2 +1,3 @@
 "line-length": false
 "no-inline-html": false
+"fenced-code-language": false

--- a/hugo/content/add_genome/_index.md
+++ b/hugo/content/add_genome/_index.md
@@ -6,7 +6,7 @@ Are you a researcher affiliated with a Swedish research institution and have gen
 
 On this page, we have collected requirements and recommendations for researchers that want to add their species to the Genome Portal.
 
-#### Scope and requirements
+## Scope and requirements
 
 The Genome Portal displays genomes and associated data tracks that have been produced by researchers in Sweden. We especially encourage researchers to display data types that might otherwise not be shared via the main nucleotide repositories, such as annotations of genomic features other than Protein Coding Genes, and transcriptome assembly alignments. For more details about the scope of the Genome Portal, please see the <a href="/about" target="_blank">About page</a>.
 
@@ -21,7 +21,7 @@ For a dataset to be included in the Genome Portal, it needs to fulfill the follo
 
 4. All data that is displayed in the Genome Portal needs to be **publicly available in external repositories** (such as ENA, NCBI, Figshare, Zenodo, etc.). No data is hosted on the Genome Portal itself. Our recommendations for how to share data can be found below.
 
-#### Recommendations
+## Recommendations
 
 The Genome Portal is able to display many data types that are commonly used in genomics and transcriptomics studies. In the two sub-pages below we have collected recommendations about file formats and how to upload data files to public repositories. Following these will help in the process of assuring that the data is compatible for the display in the Genome Portal.
 

--- a/hugo/content/add_genome/_index.md
+++ b/hugo/content/add_genome/_index.md
@@ -2,18 +2,18 @@
 title: Add your own genome project
 ---
 
-Are you a researcher affiliated with a Swedish research institution and have genome you would liked to be displayed in the Genome Portal? Great! We will be happy to hear about your data and discuss how we can accommodate it. Don't hesitate to <a href="/contact" target="_blank">contact us</a>.
+Are you a researcher affiliated with a Swedish research institution and have genome with annotation tracks you would liked to be displayed in the Genome Portal? Great! Please <a href="/contact" target="_blank">send us a mail</a>. We will be happy to hear about your data and discuss how we can accommodate it.
 
-On this page, we have collected requirements and recommendations for how to add a new species to the Genome Portal that we believe will aid in the conversation when contacting us.
+On this page, we have collected requirements and recommendations for researchers that want to add their species to the Genome Portal.
 
 #### Scope and requirements
 
 The Genome Portal displays genomes and associated data tracks that have been produced by researchers in Sweden. We especially encourage researchers to display data types that might otherwise not be shared via the main nucleotide repositories, such as annotations of genomic features other than Protein Coding Genes, and transcriptome assembly alignments. For more details about the scope of the Genome Portal, please see the <a href="/about" target="_blank">About page</a>.
 
 For a dataset to be included in the Genome Portal, it needs to fulfill the following requirements:
-*[Please note that these might be subject to change in the future]*
+[*Please note that these might be subject to change in the future*]
 
-1. The genome needs to have been co-authored by **researchers affiliated to a Swedish research institution**. Please note that the organism itself does not need occur naturally in Sweden.
+1. The genome needs to have been co-authored by **researchers affiliated to a Swedish research institution**. Note that the organism itself does not need occur naturally in Sweden.
 
 2. **No human data** is allowed in the Genome Portal.
 

--- a/hugo/content/add_genome/_index.md
+++ b/hugo/content/add_genome/_index.md
@@ -2,4 +2,29 @@
 title: Add your own genome project
 ---
 
-Page describing the protocol for a researcher/research group to add their dataset to our website.
+Are you a researcher affiliated with a Swedish research institution and have genome you would liked to be displayed in the Genome Portal? Great! We will be happy to hear about your data and discuss how we can accommodate it. Don't hesitate to <a href="/contact" target="_blank">contact us</a>.
+
+On this page, we have collected requirements and recommendations for how to add a new species to the Genome Portal that we believe will aid in the conversation when contacting us.
+
+#### Scope and requirements
+
+The Genome Portal displays genomes and associated data tracks that have been produced by researchers in Sweden. We especially encourage researchers to display data types that might otherwise not be shared via the main nucleotide repositories, such as annotations of genomic features other than Protein Coding Genes, and transcriptome assembly alignments. For more details about the scope of the Genome Portal, please see the <a href="/about" target="_blank">About page</a>.
+
+For a dataset to be included in the Genome Portal, it needs to fulfill the following requirements:
+*[Please note that these might be subject to change in the future]*
+
+1. The genome needs to have been co-authored by **researchers affiliated to a Swedish research institution**. Please note that the organism itself does not need occur naturally in Sweden.
+
+2. **No human data** is allowed in the Genome Portal.
+
+3. For a new species to be considered for inclusion in the Genome Portal, it needs **at minimum to have a genome assembly and an annotation of protein coding genes**.
+
+4. All data that is displayed in the Genome Portal needs to be **publicly available in external repositories** (such as ENA, NCBI, Figshare, Zenodo, etc.). No data is hosted on the Genome Portal itself. Our recommendations for how to share data can be found below.
+
+#### Recommendations
+
+The Genome Portal is able to display many data types that are commonly used in genomics and transcriptomics studies. In the two sub-pages below we have collected recommendations about file formats and how to upload data files to public repositories. Following these will help in the process of assuring that the data is compatible for the display in the Genome Portal.
+
+* <a href="/add_genome/recommendations_for_file_formats">Recommendations for file formats</a>
+
+* <a href="/add_genome/recommendations_for_making_data_public">Recommendations of how to make data files publicly available</a>

--- a/hugo/content/add_genome/recommendations_for_file_formats.md
+++ b/hugo/content/add_genome/recommendations_for_file_formats.md
@@ -2,15 +2,17 @@
 title: Recommendations for file formats
 ---
 
+## Recommendations for file formats
+
 This page contains recommendations for the file formats that can be used for displaying data on the Genome Portal and is intended as a support for researchers that want to add a new genome to the site. The text assumes some previous knowledge about bioinformatics file formats and familiarity with command line tools. The Genome Portal staff will also be happy to discuss choice of file formats and give advice on file format conversion. Please see the <a href="/contact">Contact page</a> for how to get in touch with us.
 
 The Genome Portal uses JBrowse 2 to display the datasets. JBrowse 2 <a href="https://jbrowse.org/jb2/features/#supported-data-formats">supports several formats</a> that are commonly used in genomics and transcriptomics and these can thus technically be displayed in the genome portal. However, at the moment we do **NOT display BAM files** in the genome portal since they can be quite big and might affect performance.
 
 - We still encourage research groups to make their BAM files publicly available, since that enables users to load the data as a local custom tracks in their JBrowse 2 instance.
 
-Readers that have looked at the <a href="https://jbrowse.org/jb2/features/#supported-data-formats">list of file formats supported by JBrowse</a> might have noticed the mention of index files. Indexing of files is taken care of on the server side of the Genome Portal, and therefore index files do not need to be supplied in the process of adding a new species to the portal. For advanced users, a description of how indexing can be performed is available in the [Additional Resources](#additional-resources) section below.
+Readers that have looked at the list of file formats supported by JBrowse might have noticed the mention of index files. Indexing of files is taken care of on the server side of the Genome Portal, and therefore index files do not need to be supplied in the process of adding a new species to the portal. For advanced users, a description of how indexing can be performed is available in the [Additional Resources](#additional-resources) section below.
 
-The Genome Portal project advocates the FAIR principles for sharing of research data. As part of this work, all datasets are required to have been made publicly available in repositories that uses persistent identifiers. We therefore encourage researchers that are interested in adding a genome to the Genome Portal to first read this guide on file format recommendations and then read the recommendations for how to make the data files publicly available that can be found <a href="/add_genome/recommendations_for_making_data_public">here</a>.
+The Genome Portal project advocates the FAIR principles for sharing of research data. As part of this work, all datasets are required to have been made publicly available in repositories that uses persistent identifiers. We therefore encourage researchers that are interested in adding a genome to the Genome Portal to first read this guide on file format recommendations and then read the <a href="/add_genome/recommendations_for_making_data_public">recommendations for how to make the data files publicly available</a>.
 
 The data that is displayed in JBrowse 2 can be divided in two groups: [genome assemblies](#genome-assemblies) and [data tracks](#data-tracks). Below follows specific recommendations for making sure that the data is compatible with JBrowse.
 
@@ -50,7 +52,7 @@ GTF is another format for storing annotations that is very similar format to GFF
 
 There are several bioinformatics tools that can convert GTF and older GFF versions to GFF3. We recommend using <a href="https://agat.readthedocs.io">AGAT</a>. This is a command line toolkit designed by the NBIS bioinformatics platform at SciLifeLab. The AGAT script `agat_convert_sp_gxf2gxf.pl` is used to achieve conversions from GFF and GTF to GFF3.
 
-```text
+```
 # Usage example based on the AGAT documentation
 # https://agat.readthedocs.io/en/latest/tools/agat_convert_sp_gxf2gxf.html
 
@@ -67,7 +69,7 @@ JBrowse 2 also supports the bigBED format which is a binary, indexed format whic
 
 JBrowse does not support the EMBL annotation format, but it can be converted to GFF with the AGAT toolkit which was also discussed in the GFF/GTF section above. Note that a different different AGAT script is needed for converting EMBL file: `agat_convert_sp_gxf2gxf.pl`.
 
-```text
+```
 # Usage example based on the AGAT documentation
 # https://agat.readthedocs.io/en/latest/tools/agat_convert_embl2gff.html
 
@@ -80,7 +82,7 @@ A common methodology to predict repeated sequences (“repeats”) in genome ass
 
 BED: The .out format is very similar in its formatting to .bed and can easily be converted using established bioinformatics tools. Below is an example of how to use the `convert2bed` function of the  <a href="https://bedops.readthedocs.io/">BEDOPS toolkit</a> to perform the conversion.
 
-```text
+```
 # Usage example based on the BEDOPS documentation
 # https://bedops.readthedocs.io/en/latest/content/reference/file-management/conversion/convert2bed.html
 
@@ -115,7 +117,7 @@ The seminal biinformatics toolkit SAMtools can be used to handle all the require
 
 FASTA files can be indexed using the `samtools faidx` command.
 
-```text
+```
 # Example of standard fasta indexing with SAMtools:
 # this command will index the file 'assembly.fasta' and create an
 # index file named 'assembly.fasta.fai' in the same directory as the fasta
@@ -125,7 +127,7 @@ samtools faidx path/to/assembly.fasta
 
 Furthermore, it is common to compress the FASTA file before indexing to save storage space. SAMtools comes with the bgzip compression tool, which compresses the file in a manner similar to gzip but with optimization suitable for genomics and transcriptomics data. Note that JBrowse 2 only supports bgzipped files and not regular gzipped files. This means that fasta.gz files downloaded from ENA and NCBI might not be displayable without first unzipping them and re-compressing them with bgzip.
 
-```text
+```
 # Example of bgzipping and indexing of fasta files with SAMtools
 # faidx supports bgzipped files as input, so the code can be modified as:
 # (the resulting file will be named assembly.fasta.bgz.fai)
@@ -144,7 +146,7 @@ To be able to display data tracks that use a different version of the formatting
 
 - Example from the Clouded Apollo refNameAlias file:
 
-```text
+```
 #ENA_formatted_header #NCBI_formatted_header #original_header
 ENA|CAVLGL010000001|CAVLGL010000001.1 CAVLGL010000001.1 scaffold_1
 ENA|CAVLGL010000002|CAVLGL010000002.1 CAVLGL010000002.1 scaffold_10

--- a/hugo/content/add_genome/recommendations_for_file_formats.md
+++ b/hugo/content/add_genome/recommendations_for_file_formats.md
@@ -2,9 +2,9 @@
 title: Recommendations for file formats
 ---
 
-This page contains recommendations for the file formats that can be used for displaying data on the Genome Portal and is intended as a support for researchers that want to add a new genome to the site. The text assumes some previous knowledge about bioinformatics file formats and familiarity with command line tools. The Genome Portal staff will also be happy to discuss choice of file formats and give advice on file format conversion. Please see the <a href="/contact">Contact page</a> for how to easiest get in touch with us.
+This page contains recommendations for the file formats that can be used for displaying data on the Genome Portal and is intended as a support for researchers that want to add a new genome to the site. The text assumes some previous knowledge about bioinformatics file formats and familiarity with command line tools. The Genome Portal staff will also be happy to discuss choice of file formats and give advice on file format conversion. Please see the <a href="/contact">Contact page</a> for how to get in touch with us.
 
-The Genome Portal uses JBrowse 2 to display the datasets. JBrowse 2 supports several formats that are commonly used in genomics and transcriptomics (see this <a href="https://jbrowse.org/jb2/features/#supported-data-formats">link</a> for a full list) and these can thus technically be displayed in the genome portal. However, at the moment we do **NOT display BAM files** in the genome portal since they can be quite big and might affect performance.
+The Genome Portal uses JBrowse 2 to display the datasets. JBrowse 2 <a href="https://jbrowse.org/jb2/features/#supported-data-formats">supports several formats</a> that are commonly used in genomics and transcriptomics and these can thus technically be displayed in the genome portal. However, at the moment we do **NOT display BAM files** in the genome portal since they can be quite big and might affect performance.
 
 - We still encourage research groups to make their BAM files publicly available, since that enables users to load the data as a local custom tracks in their JBrowse 2 instance.
 
@@ -12,7 +12,7 @@ Readers that have looked at the <a href="https://jbrowse.org/jb2/features/#suppo
 
 The Genome Portal project advocates the FAIR principles for sharing of research data. As part of this work, all datasets are required to have been made publicly available in repositories that uses persistent identifiers. We therefore encourage researchers that are interested in adding a genome to the Genome Portal to first read this guide on file format recommendations and then read the recommendations for how to make the data files publicly available that can be found <a href="/add_genome/recommendations_for_making_data_public">here</a>.
 
-The data that is displayed in JBrowse 2 can be divided in two groups: genome assemblies and data tracks. Below follows specific recommendations for making sure that the data is compatible with JBrowse.
+The data that is displayed in JBrowse 2 can be divided in two groups: [genome assemblies](#genome-assemblies) and [data tracks](#data-tracks). Below follows specific recommendations for making sure that the data is compatible with JBrowse.
 
 ### Genome assemblies
 
@@ -48,11 +48,12 @@ One of the most common formats for storing annotations for genomic features is G
 
 GTF is another format for storing annotations that is very similar format to GFF. However, JBrowse 2 does support GTF files and they therefore also need to be converted to GFF3.
 
-There are several bioinformatics tools that can convert GTF and older GFF versions to GFF3. We recommend using AGAT (<https://agat.readthedocs.io>). This is a command line toolkit designed by the NBIS bioinformatics platform at SciLifeLab. The AGAT script `agat_convert_sp_gxf2gxf.pl` is used to achieve conversions from GFF and GTF to GFF3.
+There are several bioinformatics tools that can convert GTF and older GFF versions to GFF3. We recommend using <a href="https://agat.readthedocs.io">AGAT</a>. This is a command line toolkit designed by the NBIS bioinformatics platform at SciLifeLab. The AGAT script `agat_convert_sp_gxf2gxf.pl` is used to achieve conversions from GFF and GTF to GFF3.
 
-```bash
+```text
 # Usage example based on the AGAT documentation
 # https://agat.readthedocs.io/en/latest/tools/agat_convert_sp_gxf2gxf.html
+
 agat_convert_sp_gxf2gxf.pl -g annotation_file1.gtf --output annotation_file1.gff
 ```
 
@@ -60,27 +61,29 @@ agat_convert_sp_gxf2gxf.pl -g annotation_file1.gtf --output annotation_file1.gff
 
 Another very common format for describing genomic features is BED (Browser Extensible Data). BED files have a less complicated version history than GFF/GTF and should, in general, be directly compatible with JBrowse 2. Note that BED documentation sometimes discusses BED followed with a number, such as BED3, BED6, BED12. The numbers indicate the number of the established BED columns that are included in that particular BED file. The first three columns are mandatory, meaning that BED3 is the minimal formatting for a BED file. To our knowledge, JBrowse 2 supports BED versions with different number of columns as long as the number of columns are consistent across the rows within each BED file.
 
-JBrowse 2 also supports the bigBED format which is a binary, indexed format which is recommended for large BED-formatted datasets in order to improve performance. See this documentation for how to convert BED to bigBED: <https://genome.ucsc.edu/goldenPath/help/bigBed.html>.
+JBrowse 2 also supports the bigBED format which is a binary, indexed format which is recommended for large BED-formatted datasets in order to improve performance. Please see the <a href="https://genome.ucsc.edu/goldenPath/help/bigBed.html">bigBED documentation</a> for how to convert BED to bigBED.
 
 #### EMBL
 
 JBrowse does not support the EMBL annotation format, but it can be converted to GFF with the AGAT toolkit which was also discussed in the GFF/GTF section above. Note that a different different AGAT script is needed for converting EMBL file: `agat_convert_sp_gxf2gxf.pl`.
 
-```bash
+```text
 # Usage example based on the AGAT documentation
 # https://agat.readthedocs.io/en/latest/tools/agat_convert_embl2gff.html
+
 agat_converter_embl2gff.pl --embl annotation_file2.embl --output annotation_file2.gff
 ```
 
 #### RepeatMasker output format (.out)
 
-A common methodology to predict repeated sequences (“repeats”) in genome assemblies is to use the RepeatModeller and RepeatMasker software (<https://www.repeatmasker.org/>). The default setting of the RepeatModeller/RepeatMasker pipeline is to output an annotation file in the proprietary format .out, which is not supported by JBrowse. Thus, we recommend on of these two options: convert to BED or convert to GFF.
+A common methodology to predict repeated sequences (“repeats”) in genome assemblies is to use the <a href="https://www.repeatmasker.org/">RepeatModeller and RepeatMasker software</a>. The default setting of the RepeatModeller/RepeatMasker pipeline is to output an annotation file in the proprietary format .out, which is not supported by JBrowse. Thus, we recommend on of these two options: convert to BED or convert to GFF.
 
-BED: The .out format is very similar in its formatting to .bed and can easily be converted using established bioinformatics tools. Below is an example of how to use the `convert2bed` function of the BEDOPS toolkit (<https://bedops.readthedocs.io/> ) to perform the conversion.
+BED: The .out format is very similar in its formatting to .bed and can easily be converted using established bioinformatics tools. Below is an example of how to use the `convert2bed` function of the  <a href="https://bedops.readthedocs.io/">BEDOPS toolkit</a> to perform the conversion.
 
-```bash
+```text
 # Usage example based on the BEDOPS documentation
 # https://bedops.readthedocs.io/en/latest/content/reference/file-management/conversion/convert2bed.html
+
 convert2bed --input=rmsk --output=bed < repeats.out > repeats.bed
 ```
 
@@ -96,48 +99,42 @@ We still encourage research groups to make their .bam files publicly available, 
 
 #### Links to format documentation
 
-- FASTA: <https://www.ncbi.nlm.nih.gov/genbank/fastaformat/>
+- <a href="https://www.ncbi.nlm.nih.gov/genbank/fastaformat/">FASTA definition</a>
 
-- GFF3: <https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md>
+- <a href="https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md">GFF3 definition</a> and a comprehensive <a href="ttps://agat.readthedocs.io/en/latest/gxf.html"> overview of GTF and older GFF versions</a>
 
-- A comprehensive overview of GTF and older GFF versions: <https://agat.readthedocs.io/en/latest/gxf.html>
+- <a href="https://samtools.github.io/hts-specs/BEDv1.pdf">BED definition</a>
 
-- BED: <https://samtools.github.io/hts-specs/BEDv1.pdf>
-
-- RepeatMasker .out (see section 3): <https://www.genome.iastate.edu/bioinfo/resources/manuals/RepeatMasker.html>
+- <a href="https://www.genome.iastate.edu/bioinfo/resources/manuals/RepeatMasker.html">RepeatMasker .out format</a> (see Section 3 in link)
 
 #### Indexing of data files is required for certain file formats
 
-Fasta, GFF, BED and VCF files need to be indexed in order to be displayed with JBrowse 2. In short, indexing enables large genomes to be browsable while minimizing the negative effect on performance. As mentioned above, this will be done on the server side when a new species is added to the Genome Portal. However, if a user wants to download the datasets and view them in e.g. the JBrowse Desktop client (<https://jbrowse.org/jb2/download/>), the index files need to be supplied by the user.
+Fasta, GFF, BED and VCF files need to be indexed in order to be displayed with JBrowse 2. In short, indexing enables large genomes to be browsable while minimizing the negative effect on performance. As mentioned above, this will be done on the server side when a new species is added to the Genome Portal. However, if a user wants to download the datasets and view them in e.g. the  <a href="https://jbrowse.org/jb2/download/">JBrowse Desktop client</a>, the index files need to be supplied by the user.
 
 The seminal biinformatics toolkit SAMtools can be used to handle all the required indexing.  It is a command line tool, and will thus require some knowledge on how to run and install this kind of software.
 
 FASTA files can be indexed using the `samtools faidx` command.
 
-```bash
+```text
 # Example of standard fasta indexing with SAMtools:
 # this command will index the file 'assembly.fasta' and create an
 # index file named 'assembly.fasta.fai' in the same directory as the fasta
+
 samtools faidx path/to/assembly.fasta
 ```
 
 Furthermore, it is common to compress the FASTA file before indexing to save storage space. SAMtools comes with the bgzip compression tool, which compresses the file in a manner similar to gzip but with optimization suitable for genomics and transcriptomics data. Note that JBrowse 2 only supports bgzipped files and not regular gzipped files. This means that fasta.gz files downloaded from ENA and NCBI might not be displayable without first unzipping them and re-compressing them with bgzip.
 
-```bash
+```text
 # Example of bgzipping and indexing of fasta files with SAMtools
 # faidx supports bgzipped files as input, so the code can be modified as:
 # (the resulting file will be named assembly.fasta.bgz.fai)
+
 bgzip < path/to/assembly.fasta > path/to/assembly.fasta.bgz
 samtools faidx path/to/assembly.fasta.bgz
 ```
 
-The above examples were adapted from the manual pages for faidx, bgzip, and tabix, which are available here:
-
-<http://www.htslib.org/doc/samtools-faidx.html>
-
-<https://www.htslib.org/doc/bgzip.html>
-
-<https://www.htslib.org/doc/tabix.html>
+The above examples were adapted from the manual pages for <a href="http://www.htslib.org/doc/samtools-faidx.html">faidx</a>, <a href="https://www.htslib.org/doc/bgzip.html">bgzip</a>, and <a href="https://www.htslib.org/doc/tabix.html">tabix</a>.
 
 #### refNameAlias - displaying data tracks on an assembly version when the FASTA header formatting differs
 

--- a/hugo/content/add_genome/recommendations_for_file_formats.md
+++ b/hugo/content/add_genome/recommendations_for_file_formats.md
@@ -1,0 +1,158 @@
+---
+title: Recommendations for file formats
+---
+
+This page contains recommendations for the file formats that can be used for displaying data on the Genome Portal and is intended as a support for researchers that want to add a new genome to the site. The text assumes some previous knowledge about bioinformatics file formats and familiarity with command line tools. The Genome Portal staff will also be happy to discuss choice of file formats and give advice on file format conversion. Please see the <a href="/contact">Contact page</a> for how to easiest get in touch with us.
+
+The Genome Portal uses JBrowse 2 to display the datasets. JBrowse 2 supports several formats that are commonly used in genomics and transcriptomics (see this <a href="https://jbrowse.org/jb2/features/#supported-data-formats">link</a> for a full list) and these can thus technically be displayed in the genome portal. However, at the moment we do **NOT display BAM files** in the genome portal since they can be quite big and might affect performance.
+
+- We still encourage research groups to make their BAM files publicly available, since that enables users to load the data as a local custom tracks in their JBrowse 2 instance.
+
+Readers that have looked at the <a href="https://jbrowse.org/jb2/features/#supported-data-formats">list of file formats supported by JBrowse</a> might have noticed the mention of index files. Indexing of files is taken care of on the server side of the Genome Portal, and therefore index files do not need to be supplied in the process of adding a new species to the portal. For advanced users, a description of how indexing can be performed is available in the [Additional Resources](#additional-resources) section below.
+
+The Genome Portal project advocates the FAIR principles for sharing of research data. As part of this work, all datasets are required to have been made publicly available in repositories that uses persistent identifiers. We therefore encourage researchers that are interested in adding a genome to the Genome Portal to first read this guide on file format recommendations and then read the recommendations for how to make the data files publicly available that can be found <a href="/add_genome/recommendations_for_making_data_public">here</a>.
+
+The data that is displayed in JBrowse 2 can be divided in two groups: genome assemblies and data tracks. Below follows specific recommendations for making sure that the data is compatible with JBrowse.
+
+### Genome assemblies
+
+The assemblies should contain a nucleotide sequence formatted in multi-FASTA form. The file should preferably be compressed using gzip since assembly files can often have a large size.
+
+#### Primary assemblies
+
+Most scientific journals enforce open sharing of genome assembly data in order to accept scientific manuscripts for publication, which typically means that the assembly and annotation of protein coding genes will be submitted to one of the international nucleotide databases, such as the European Nucleotide Archive (ENA), and NCBI GenBank. For assemblies made available in these two databases, it is sufficient to give us the Accession Number.
+
+- Example of a typical file name: `atlantic_herring_assembly.fa.gz`
+
+- Example of an ENA/NCBI accession number: `GCA_900323705`
+
+Since the Genome Portal is developed at SciLifeLab, which is situated in Europe, it has been decided that the Genome Portal will use the ENA version of all genome assemblies as a default. Since ENA and NCBI mirror their data, a assembly downloaded from either of the two databases will contain the same nucleotide sequence. They will however differ in how the FASTA headers are formatted; this can create some incompatibilities with data tracks that assume a certain header format, but this is handled in the Genome Portal by using so-called refNameAlias files. Alias files and the process of generating them are described in the [Additional Resources](#additional-resources) section below.
+
+Sometimes a research group might have reasons to use a version of their genome assembly in the Genome Portal other than the versions available on ENA/NCBI. We will likely be able to accommodate that instead of the ENA version. The Genome Portal is only able to display one primary genome assembly version per species. We still strongly encourage that a version of the assembly is made publicly available through ENA or NCBI.
+
+#### Organelle assemblies
+
+It is also possible to display separate assemblies from organelles in the genome browser, such as mitochondria and chloroplasts. In order to display organelle assemblies, we require that they have a gene annotation. Please note that we do not display just organelles in Genome Portal: there also has to be a primary genome assembly from the same species. The same file format recommendations as for primary genome assemblies apply: FASTA files that are preferably gzip-compressed.
+
+### Data tracks
+
+In the context of the genome browser, all other compatible data that describe the assembly is referred to as data tracks. These include annotation of protein coding genes, repeats, tRNA, ncRNA, transcriptome assemblies, to name a few. Some data types tend to come in a specific format (such as VCF for nucleotide variants), whereas some data types can come in several different formats. The Genome Portal does not enforce the use over a certain format over another for the data tracks as long as the format is supported by JBrowse 2. Researchers can thus to a large extent use to use their domain-specific conventions when choosing data format.
+
+Unlike genome assemblies, it is possible to include multiple versions of a data track in the Genome Portal if desired. For instance, a research group might have a version of the Protein Coding Genes track that uses in-house annotations of the gene names that differ from naming format of the version of the track available at NCBI. For cases such as these, we recommend that both tracks are included since this increases clarity and facilitates comparison between the track versions.
+
+In the subsections below we have collected specific recommendations for some commonly used data track file formats.
+
+#### GFF (and GTF)
+
+One of the most common formats for storing annotations for genomic features is GFF (General Feature Format). NCBI for instance uses this for Protein Coding Genes. JBrowse 2 specifically supports the GFF3 version, and older GFF formats thus need to be converted to GFF3 as described below.
+
+GTF is another format for storing annotations that is very similar format to GFF. However, JBrowse 2 does support GTF files and they therefore also need to be converted to GFF3.
+
+There are several bioinformatics tools that can convert GTF and older GFF versions to GFF3. We recommend using AGAT (<https://agat.readthedocs.io>). This is a command line toolkit designed by the NBIS bioinformatics platform at SciLifeLab. The AGAT script `agat_convert_sp_gxf2gxf.pl` is used to achieve conversions from GFF and GTF to GFF3.
+
+```bash
+# Usage example based on the AGAT documentation
+# https://agat.readthedocs.io/en/latest/tools/agat_convert_sp_gxf2gxf.html
+agat_convert_sp_gxf2gxf.pl -g annotation_file1.gtf --output annotation_file1.gff
+```
+
+#### BED
+
+Another very common format for describing genomic features is BED (Browser Extensible Data). BED files have a less complicated version history than GFF/GTF and should, in general, be directly compatible with JBrowse 2. Note that BED documentation sometimes discusses BED followed with a number, such as BED3, BED6, BED12. The numbers indicate the number of the established BED columns that are included in that particular BED file. The first three columns are mandatory, meaning that BED3 is the minimal formatting for a BED file. To our knowledge, JBrowse 2 supports BED versions with different number of columns as long as the number of columns are consistent across the rows within each BED file.
+
+JBrowse 2 also supports the bigBED format which is a binary, indexed format which is recommended for large BED-formatted datasets in order to improve performance. See this documentation for how to convert BED to bigBED: <https://genome.ucsc.edu/goldenPath/help/bigBed.html>.
+
+#### EMBL
+
+JBrowse does not support the EMBL annotation format, but it can be converted to GFF with the AGAT toolkit which was also discussed in the GFF/GTF section above. Note that a different different AGAT script is needed for converting EMBL file: `agat_convert_sp_gxf2gxf.pl`.
+
+```bash
+# Usage example based on the AGAT documentation
+# https://agat.readthedocs.io/en/latest/tools/agat_convert_embl2gff.html
+agat_converter_embl2gff.pl --embl annotation_file2.embl --output annotation_file2.gff
+```
+
+#### RepeatMasker output format (.out)
+
+A common methodology to predict repeated sequences (“repeats”) in genome assemblies is to use the RepeatModeller and RepeatMasker software (<https://www.repeatmasker.org/>). The default setting of the RepeatModeller/RepeatMasker pipeline is to output an annotation file in the proprietary format .out, which is not supported by JBrowse. Thus, we recommend on of these two options: convert to BED or convert to GFF.
+
+BED: The .out format is very similar in its formatting to .bed and can easily be converted using established bioinformatics tools. Below is an example of how to use the `convert2bed` function of the BEDOPS toolkit (<https://bedops.readthedocs.io/> ) to perform the conversion.
+
+```bash
+# Usage example based on the BEDOPS documentation
+# https://bedops.readthedocs.io/en/latest/content/reference/file-management/conversion/convert2bed.html
+convert2bed --input=rmsk --output=bed < repeats.out > repeats.bed
+```
+
+GFF: The RepeatMasker GitHub contains a script `util/rmOutToGFF3.pl` for conversion of .out to GFF3. It is also possible to (re-)run RepeatMasker with the `--gff` flag to have the software produce both an .out and a .gff file. However, this output will be formatted according to GFF2, and thus need to be converted to GFF3 for compatibility with JBrowse (e.g. with AGAT as described above).
+
+#### BAM
+
+To repeat the message from the top of the page: At the moment we **do NOT display BAM files** in the genome portal since they can be quite big and might affect performance.
+
+We still encourage research groups to make their .bam files publicly available, since that enables users to load the data as a local custom tracks in their JBrowse 2 instance.
+
+### Additional resources
+
+#### Links to format documentation
+
+- FASTA: <https://www.ncbi.nlm.nih.gov/genbank/fastaformat/>
+
+- GFF3: <https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md>
+
+- A comprehensive overview of GTF and older GFF versions: <https://agat.readthedocs.io/en/latest/gxf.html>
+
+- BED: <https://samtools.github.io/hts-specs/BEDv1.pdf>
+
+- RepeatMasker .out (see section 3): <https://www.genome.iastate.edu/bioinfo/resources/manuals/RepeatMasker.html>
+
+#### Indexing of data files is required for certain file formats
+
+Fasta, GFF, BED and VCF files need to be indexed in order to be displayed with JBrowse 2. In short, indexing enables large genomes to be browsable while minimizing the negative effect on performance. As mentioned above, this will be done on the server side when a new species is added to the Genome Portal. However, if a user wants to download the datasets and view them in e.g. the JBrowse Desktop client (<https://jbrowse.org/jb2/download/>), the index files need to be supplied by the user.
+
+The seminal biinformatics toolkit SAMtools can be used to handle all the required indexing.  It is a command line tool, and will thus require some knowledge on how to run and install this kind of software.
+
+FASTA files can be indexed using the `samtools faidx` command.
+
+```bash
+# Example of standard fasta indexing with SAMtools:
+# this command will index the file 'assembly.fasta' and create an
+# index file named 'assembly.fasta.fai' in the same directory as the fasta
+samtools faidx path/to/assembly.fasta
+```
+
+Furthermore, it is common to compress the FASTA file before indexing to save storage space. SAMtools comes with the bgzip compression tool, which compresses the file in a manner similar to gzip but with optimization suitable for genomics and transcriptomics data. Note that JBrowse 2 only supports bgzipped files and not regular gzipped files. This means that fasta.gz files downloaded from ENA and NCBI might not be displayable without first unzipping them and re-compressing them with bgzip.
+
+```bash
+# Example of bgzipping and indexing of fasta files with SAMtools
+# faidx supports bgzipped files as input, so the code can be modified as:
+# (the resulting file will be named assembly.fasta.bgz.fai)
+bgzip < path/to/assembly.fasta > path/to/assembly.fasta.bgz
+samtools faidx path/to/assembly.fasta.bgz
+```
+
+The above examples were adapted from the manual pages for faidx, bgzip, and tabix, which are available here:
+
+<http://www.htslib.org/doc/samtools-faidx.html>
+
+<https://www.htslib.org/doc/bgzip.html>
+
+<https://www.htslib.org/doc/tabix.html>
+
+#### refNameAlias - displaying data tracks on an assembly version when the FASTA header formatting differs
+
+When assemblies and annotations are uploaded to ENA or NCBI, some repository-specific reformatting of FASTA headers will occur. The original header will be replaced by new version that is based on the Accession Number that the upload will be given once accepted in the ENA or NCBI databases. If a data track does not use the same FASTA header as the assembly, it cannot be displayed in JBrowse 2. However, not all data tracks are or even can be uploaded to ENA or NCBI, and there are therefore many use-cases where a data track might not follow the ENA or NCBI FASTA header formatting.
+
+To be able to display data tracks that use a different version of the formatting, a refNameAlias (“alias”) file is needed. The alias file contains links between each FASTA header in the assembly and all their known synonymous names. It is a tab separated file where the first column contains the FASTA header from the version of the assembly that will be used in JBrowse 2, and each following column the synonyms.
+
+- Example from the Clouded Apollo refNameAlias file:
+
+```text
+#ENA_formatted_header #NCBI_formatted_header #original_header
+ENA|CAVLGL010000001|CAVLGL010000001.1 CAVLGL010000001.1 scaffold_1
+ENA|CAVLGL010000002|CAVLGL010000002.1 CAVLGL010000002.1 scaffold_10
+ENA|CAVLGL010000003|CAVLGL010000003.1 CAVLGL010000003.1 scaffold_100
+ENA|CAVLGL010000004|CAVLGL010000004.1 CAVLGL010000004.1 scaffold_101
+```
+
+For genome assemblies that contain a low number of scaffolds (say, less than 10-20), this file can easily be generate by hand. But some scripting might be needed for cases that contains a higher number. During the process of adding a new species to the Genome Portal, the staff will generate the alias file. The file will then be publicly shared in the <a href="https://figshare.scilifelab.se/">SciLifeLab Data Repository</a>.

--- a/hugo/content/add_genome/recommendations_for_making_data_public.md
+++ b/hugo/content/add_genome/recommendations_for_making_data_public.md
@@ -6,7 +6,7 @@ The Genome Portal uses the FAIR principles as a guidance for sharing of research
 
 - For more information on the FAIR principles, we recommend <a href="https://data-guidelines.scilifelab.se/topics/fair-principles/ ">this page</a> from SciLifeLab.
 
-Below we list three recommendations of how to share research data in a manner that follows the FAIR principles and facilitates the integration with the Genome Portal. For recommendations for the file formats that can be used for displaying data on the Genome Portal, please see this  <a href="/add_genome/recommendations_for_file_formats">page</a>.
+Below we list three recommendations of how to share research data in a manner that follows the FAIR principles and facilitates the integration with the Genome Portal. For information relating to the data files themselves, please also see the <a href="/add_genome/recommendations_for_file_formats"> recommendations for file formats</a> for displaying data on the Genome Portal.
 
 #### Recommendations
 
@@ -26,9 +26,11 @@ Below we list three recommendations of how to share research data in a manner th
 
     - Note! The persistent identifier can refer to a collection of data files, e.g. an Acession Number on ENA/NCBI or a DOI to a SciLifeLab Data Repository submission, but each file that is connected to that persistent identifier need to have its own download URL.
 
-3. The files should be compressed to save disk size. It is recommended to use gzip (.gz) since this is very common compression format used in bioinformatics, which is for instance used by the major repositories ENA (European Nucleotide Archive) and NCBI GenBank for storing and sharing genome assembly data. Additionally, gzip natively only supports single files, which helps adhere to the bullet number 2 above.
+3. The files should be compressed to save disk size. It is recommended to use gzip (.gz) since this is very common compression format used in bioinformatics. It is for instance used by the major repositories ENA (European Nucleotide Archive) and NCBI GenBank for storing and sharing genome assembly data.
 
-    - It might be tempting to add multiple files to an archive (e.g. .tar) and compressing them together (e.g. .tar.gz), but this not suitable for compatibility with the Genome Portal. Instead use gzip to compress each file separately.
+    - Gzip itself only supports single files as input, which helps adhere to the bullet number 2 above.
+
+    - It might be tempting to add multiple files to an archive (e.g. .tar) and compressing them together (e.g. .tar.gz), but this not suitable for compatibility with the Genome Portal.
 
 #### Example
 

--- a/hugo/content/add_genome/recommendations_for_making_data_public.md
+++ b/hugo/content/add_genome/recommendations_for_making_data_public.md
@@ -1,0 +1,45 @@
+---
+title: Recommendations of how to make data files publicly available
+---
+
+The Genome Portal uses the FAIR principles as a guidance for sharing of research data. FAIR encourages researchers to make their data Findable, Accessible, Interoperable, and Reusable. One of the ways that we encourage this is by requiring that all data that is displayed in the Genome Portal is submitted to external research data repositories. In this way, we hope that many valuable datasets that otherwise might not be shared via the main nucleotide repositories can be made public.
+
+- For more information on the FAIR principles, we recommend <a href="https://data-guidelines.scilifelab.se/topics/fair-principles/ ">this page</a> from SciLifeLab.
+
+Below we list three recommendations of how to share research data in a manner that follows the FAIR principles and facilitates the integration with the Genome Portal. For recommendations for the file formats that can be used for displaying data on the Genome Portal, please see this  <a href="/add_genome/recommendations_for_file_formats">page</a>.
+
+#### Recommendations
+
+1. The files should be uploaded to a repository that provides a persistent identifier, such as a DOI.
+
+    - Assemblies and annotation of protein coding genes should be uploaded to a specialized repository such as ENA (European Nucleotide Archive) and NCBI GenBank. This is a *de facto* standard in genomics and is often a requirement for submission of manuscripts to scientific journals. Files uploaded to these repositories will get a persistent identifier in the form of an Accession Number.
+
+    - For other data types that can be displayed in the Genome Portal, there are likely no specialized repositories. Therefore, such files can be submitted to a general purpose repository, such as <a href="https://figshare.scilifelab.se/">SciLifeLab Data Repository</a>, and <a href="https://zenodo.org/">Zenodo</a>.
+
+        - The Genome Portal is developed and maintained as part of the Data-Drive Life Science (DDLS) program at SciLifeLab, and we recommend users to use SciLifeLab Data Repository since we are able to give detailed advice on how to make submissions there.
+
+        - GitHub or cloud-based storage services such as Google Drive, Dropbox, etc., **are not suitable** due to the lack of agreements for persistence of files and identifiers.
+
+2. Each data file should be accessible with a unique download URL that points to that file only, and not to an archive containing several files.
+
+    - This facilitates file handling both for the Genome Portal server, and for users that want to access a specific file from a repository.
+
+    - Note! The persistent identifier can refer to a collection of data files, e.g. an Acession Number on ENA/NCBI or a DOI to a SciLifeLab Data Repository submission, but each file that is connected to that persistent identifier need to have its own download URL.
+
+3. The files should be compressed to save disk size. It is recommended to use gzip (.gz) since this is very common compression format used in bioinformatics, which is for instance used by the major repositories ENA (European Nucleotide Archive) and NCBI GenBank for storing and sharing genome assembly data. Additionally, gzip natively only supports single files, which helps adhere to the bullet number 2 above.
+
+    - It might be tempting to add multiple files to an archive (e.g. .tar) and compressing them together (e.g. .tar.gz), but this not suitable for compatibility with the Genome Portal. Instead use gzip to compress each file separately.
+
+#### Example
+
+Let’s say that a user wants to make three files publicly available by submitting them to SciLifeLab Data Repository. Assume that the files are called `data_track1.gff`, `data_track2.bed`, and `data_track3.gff`. After gziping each file on their own, there will be three files ready to be uploaded during the SciLifeLab Data Repository submission process:
+
+- `data_track1.gff.gz` (the gzipped version of the file `data_track1.gff`)
+
+- `data_track2.bed.gz` (the gzipped version of the file `data_track2.bed`)
+
+- `data_track3.gff.gz` (the gzipped version of the file `data_track3.gff`)
+
+#### Questions?
+
+ We are happy to discuss and advice on how to best practices for making research data available. Please see our <a href="/contact" target="_blank">contact details</a> for information on how to get in touch with us.

--- a/hugo/content/add_genome/recommendations_for_making_data_public.md
+++ b/hugo/content/add_genome/recommendations_for_making_data_public.md
@@ -2,13 +2,15 @@
 title: Recommendations of how to make data files publicly available
 ---
 
+## Recommendations of how to make data files publicly available
+
 The Genome Portal uses the FAIR principles as a guidance for sharing of research data. FAIR encourages researchers to make their data Findable, Accessible, Interoperable, and Reusable. One of the ways that we encourage this is by requiring that all data that is displayed in the Genome Portal is submitted to external research data repositories. In this way, we hope that many valuable datasets that otherwise might not be shared via the main nucleotide repositories can be made public.
 
-- For more information on the FAIR principles, we recommend <a href="https://data-guidelines.scilifelab.se/topics/fair-principles/ ">this page</a> from SciLifeLab.
+- For more information on the FAIR principles, we recommend <a href="https://data-guidelines.scilifelab.se/topics/fair-principles/ ">this summary </a> in the SciLifeLab Research Data Management guidelines.
 
 Below we list three recommendations of how to share research data in a manner that follows the FAIR principles and facilitates the integration with the Genome Portal. For information relating to the data files themselves, please also see the <a href="/add_genome/recommendations_for_file_formats"> recommendations for file formats</a> for displaying data on the Genome Portal.
 
-#### Recommendations
+### Recommendations
 
 1. The files should be uploaded to a repository that provides a persistent identifier, such as a DOI.
 
@@ -42,6 +44,6 @@ Let’s say that a user wants to make three files publicly available by submitti
 
 - `data_track3.gff.gz` (the gzipped version of the file `data_track3.gff`)
 
-#### Questions?
+### Questions?
 
  We are happy to discuss and advice on how to best practices for making research data available. Please see our <a href="/contact" target="_blank">contact details</a> for information on how to get in touch with us.

--- a/hugo/static/css/styles.css
+++ b/hugo/static/css/styles.css
@@ -291,14 +291,18 @@ iframe#matoOpOut {
 
 /* Styles for markdown formatting of inline code and code blocks */
 code {
-  color: black;  /* A shade of gray #6e6e6e;*/
+  color: black;
   background-color: var(--scilife-light-grey);
 }
 
 pre {
-  color: black !important;
-  background-color: var(--scilife-light-grey) !important; 
+  color: black;
+  background-color: var(--scilife-light-grey); 
   -moz-tab-size: 4;
   -o-tab-size: 4;
   tab-size: 4;
+  border: 1px solid var(--scilife-medium-grey);
+  border-radius: 10px; 
+  line-height: 1.5;
+  padding: 5px;
 }

--- a/hugo/static/css/styles.css
+++ b/hugo/static/css/styles.css
@@ -288,3 +288,17 @@ iframe#matoOpOut {
 @media (min-width: 492px)  { iframe#matoOpOut { height: 20vh; } }
 @media (min-width: 768px)  { iframe#matoOpOut { height: 15vh; } }
 @media (min-width: 1024px) { iframe#matoOpOut { height: 14vh; } }
+
+/* Styles for markdown formatting of inline code and code blocks */
+code {
+  color: black;  /* A shade of gray #6e6e6e;*/
+  background-color: var(--scilife-light-grey);
+}
+
+pre {
+  color: black !important;
+  background-color: var(--scilife-light-grey) !important; 
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+}


### PR DESCRIPTION
Added content to the 'add a new genome' info page. Created sub-pages for the recommendations texts since they are long.

Also updated the CSS to improve styling. This is the main reason for the PR, but please also look at the textual content if you want/have time.

- Markdown code notation 
The file format recommendations page use quite a few code examples formatted with back-ticks. The default configuration resulted in colors that deviate from the overall styling of the web page.
Thus updated the CSS with `code {}` and `pre {}` to use `--scilife-light-grey` for backgrounds, and black font. 
Had to use `!important` to override other rules to get it to display. Perhaps this is not best-practice? Please make changes (or revert) as you see fit!

- h3 and h4
In `_index.md` and `recommendations_for_making_data_public.md`, I used h4 instead of h3 to make it look better. But then I recall that we talked at some point about how this might break the accessibility rules for screen readers? What are your thoughts here?
