### PR TITLE
Serve site locally in Docker container

### DIFF
--- a/scripts/dockerbuild.sh
+++ b/scripts/dockerbuild.sh
@@ -5,6 +5,12 @@
 # defaults, set the SWG_DEFAULT_USER environment variable to 1.
 _DEFAULT_TAG=local
 
+docker_build () {
+    docker build "${_BUILD_ARGS[@]}" \
+	   -t "${SWG_DOCKER_IMAGE:-$_DEFAULT_IMAGE}:${SWG_DOCKER_TAG:-$_DEFAULT_TAG}" \
+	   -f "${SWG_DOCKERFILE:-$_DEFAULT_DOCKERFILE}" .
+}
+
 if [[ -z "$1" || "$1" == "data" ]];
 then
     _DEFAULT_IMAGE=ghcr.io/scilifelabdatacentre/data-builder
@@ -14,11 +20,15 @@ then
 	_BUILD_ARGS+=("--build-arg" "SWG_UID=$(id -u)")
 	_BUILD_ARGS+=("--build-arg" "SWG_GID=$(id -g)")
     fi
-    docker build "${_BUILD_ARGS[@]}" \
-	   -t "${SWG_DOCKER_IMAGE:-$_DEFAULT_IMAGE}:${SWG_DOCKER_TAG:-$_DEFAULT_TAG}" \
-	   -f "${SWG_DOCKERFILE:-$_DEFAULT_DOCKERFILE}" . && exit 0
+    docker_build && exit 0
 fi
-echo "Usage: ./scripts/dockerbuild.sh [data]" && exit 1
 
+if [[ "$1" = hugo ]]; then
+    _DEFAULT_IMAGE=ghcr.io/scilifelabdatacentre/hugo-site
+    _DEFAULT_DOCKERFILE=docker/hugo.dockerfile
+    docker_build  && exit 0
+fi
+
+echo "Usage: ./scripts/dockerbuild.sh [data | hugo]" && exit 1
 
 

--- a/scripts/dockerserve.sh
+++ b/scripts/dockerserve.sh
@@ -1,0 +1,21 @@
+# Serve hugo site locally in a docker container
+#
+# Customize the run by setting the corresponding SWG-prefixed
+# environment variables. For example, to serve on host port 8000 with
+# the `latest` image:
+#
+# SWG_PORT=8000 SWG_TAG=latest ./scripts/dockerserve.sh
+_IMAGE=ghcr.io/scilifelabdatacentre/hugo-site
+_TAG=local
+_NAME=swegene-site
+_DATA_DIR=data
+_WWW=/usr/share/nginx/html
+_PORT=8080
+
+CWD="$(pwd)"
+
+docker run -d \
+       -p "${SWG_PORT:-$_PORT}":8080 \
+       -v "$CWD/${SWG_DATA_DIR:-$_DATA_DIR}":"$_WWW/static/data" \
+       --name "${SWG_NAME:-$_NAME}" \
+       "${SWG_IMAGE:-$_IMAGE}:${SWG_TAG:-$_TAG}"

--- a/scripts/dockerserve.sh
+++ b/scripts/dockerserve.sh
@@ -7,7 +7,7 @@
 # SWG_PORT=8000 SWG_TAG=latest ./scripts/dockerserve.sh
 _IMAGE=ghcr.io/scilifelabdatacentre/hugo-site
 _TAG=local
-_NAME=swegene-site
+_NAME=swedgene-site
 _DATA_DIR=data
 _WWW=/usr/share/nginx/html
 _PORT=8080
@@ -18,4 +18,8 @@ docker run -d \
        -p "${SWG_PORT:-$_PORT}":8080 \
        -v "$CWD/${SWG_DATA_DIR:-$_DATA_DIR}":"$_WWW/static/data" \
        --name "${SWG_NAME:-$_NAME}" \
-       "${SWG_IMAGE:-$_IMAGE}:${SWG_TAG:-$_TAG}"
+       "${SWG_IMAGE:-$_IMAGE}:${SWG_TAG:-$_TAG}" && \
+     cat <<EOF
+- Web server is running in container "${SWG_NAME:-$_NAME}".
+- Site can be visited at http://localhost:${SWG_PORT:-$_PORT}
+EOF


### PR DESCRIPTION
This PR adds helper scripts to serve the Hugo site locally, with the data directory properly mounted.
- `scripts/dockerbuild.sh site` builds the `hugo-site` image tagged `local`
- `scripts/dockerserve.sh` launches web server on port `8080` with the host `data` directory mounted where JBrowse expects it.

Both scripts can be customized through the use of appropriate `SW_`-prefixed environment variables.  