### PR TITLE
Rename Docker images

### DIFF
--- a/.github/workflows/data-builder-container.yml
+++ b/.github/workflows/data-builder-container.yml
@@ -36,7 +36,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/scilifelabdatacentre/data-builder
+          images: ghcr.io/scilifelabdatacentre/swg-data-builder
           flavor: |
             latest=auto
           tags: |

--- a/.github/workflows/hugo-container.yml
+++ b/.github/workflows/hugo-container.yml
@@ -36,7 +36,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/scilifelabdatacentre/hugo-site
+          images: ghcr.io/scilifelabdatacentre/swg-hugo-site
           flavor: |
             latest=auto
           tags: |

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ To build an run the Hugo site yourself/locally you can do the following from the
 _Please note that you need to be in the root of the repository for this to work_
 
 ```bash 
-docker build -t hugo-site:local -f docker/hugo.dockerfile .
+docker build -t swg-hugo-site:local -f docker/hugo.dockerfile .
 ```
 
 You can run then run this image locally as follows: 
 
 ```bash 
-docker run -p 8080:8080 hugo-site:local
+docker run -p 8080:8080 swg-hugo-site:local
 ```
 
 The site will be then visible to you at the address: http://localhost:8080/ on your web browser. 
@@ -103,7 +103,7 @@ If you want to specfiy the image and/or tag used you can specify them via enviro
 For example:
 
 ```bash 
-SWG_DOCKER_IMAGE=ghcr.io/scilifelabdatacentre/data-builder SWG_DOCKER_TAG=docker-dir ./scripts/dockermake.sh build
+SWG_DOCKER_IMAGE=ghcr.io/scilifelabdatacentre/swg-data-builder SWG_DOCKER_TAG=docker-dir ./scripts/dockermake.sh build
 ```
 
 

--- a/scripts/dockerbuild.sh
+++ b/scripts/dockerbuild.sh
@@ -13,7 +13,7 @@ docker_build () {
 
 if [[ -z "$1" || "$1" == "data" ]];
 then
-    _DEFAULT_IMAGE=ghcr.io/scilifelabdatacentre/data-builder
+    _DEFAULT_IMAGE=ghcr.io/scilifelabdatacentre/swg-data-builder
     _DEFAULT_DOCKERFILE=docker/data.dockerfile
     declare -a _BUILD_ARGS
     if [[ -z ${SWG_DEFAULT_USER} ]];then
@@ -24,7 +24,7 @@ then
 fi
 
 if [[ "$1" = hugo ]]; then
-    _DEFAULT_IMAGE=ghcr.io/scilifelabdatacentre/hugo-site
+    _DEFAULT_IMAGE=ghcr.io/scilifelabdatacentre/swg-hugo-site
     _DEFAULT_DOCKERFILE=docker/hugo.dockerfile
     docker_build  && exit 0
 fi

--- a/scripts/dockermake.sh
+++ b/scripts/dockermake.sh
@@ -10,7 +10,7 @@
 # SWG_DOCKER_IMAGE=industrious-squirrel SWG_DOCKER_TAG=slim-buster scripts/dockerbuild.sh build
 
 _DEFAULT_TAG="latest"
-_DEFAULT_IMAGE="ghcr.io/scilifelabdatacentre/data-builder"
+_DEFAULT_IMAGE="ghcr.io/scilifelabdatacentre/swg-data-builder"
 
 CWD="$(pwd)"
 mkdir -p "${DATA_DIR:=data}" "${INSTALL_DIR:=hugo/static}"

--- a/scripts/dockerserve.sh
+++ b/scripts/dockerserve.sh
@@ -5,7 +5,7 @@
 # the `latest` image:
 #
 # SWG_PORT=8000 SWG_TAG=latest ./scripts/dockerserve.sh
-_IMAGE=ghcr.io/scilifelabdatacentre/hugo-site
+_IMAGE=ghcr.io/scilifelabdatacentre/swg-hugo-site
 _TAG=local
 _NAME=swedgene-site
 _DATA_DIR=data

--- a/scripts/rename.sh
+++ b/scripts/rename.sh
@@ -1,0 +1,16 @@
+# Helper script to rename entities appearing in configuration and scripts
+#
+# One limitation: the find or replace strings cannot contain the %
+# character.  If the --dry-run flag is passed, prints out the changes
+# that would be applied.
+
+declare -a DIRS
+if [[ ! -v DIRS ]]; then
+    DIRS=(scripts .github)
+fi
+if [[ "$1" = "--dry-run" || "$1" = "-d" ]]; then
+    shift
+    [[ -n "$1" ]] && grep -lREZ "$1" "${DIRS[@]}" | xargs -r -0 sed -n "\%$1%{F; p; s%$1%$2%p}"
+else
+    grep -lREZ "$1" "${DIRS[@]}" | xargs -r -0 sed -i "s%$1%$2%"
+fi


### PR DESCRIPTION
Prepend `swg-` to our public Docker image names to avoid naming conflicts.
Also included the script used to perform the renaming , if that is something we get into the habit of doing 🙄 
