### PR TITLE
Make species data directories readable to the world

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,4 +149,5 @@ $(filter %.gff.bgz,$(LOCAL_FILES)): %.gff.bgz: %.gff.gz
 # the local outdated copy must be deleted before running `make download`
 $(DOWNLOAD_TARGETS): $(DATA_DIR)/%:| $(DATA_DIR)/.downloads/%
 	@echo "Downloading $@ ..."; \
-	curl -# -L --create-dirs --output $@ "$$(< $|)"
+	mkdir -p --mode=0755 $(@D) && \
+	curl -# -L --output $@ "$$(< $|)"


### PR DESCRIPTION
This tiny pull request ensures that species directories created by make in `DATA_DIR` are "readable by everyone". In a Kubernetes context, this means that the `nginx` user will be able to read (and hence serve) the JBrowse configuration files.

The proposed modification was necessary because the `--create-dirs` option of `curl`, creates intermediate directories with mode 0750, which makes them unreadable for a user that is not the owner or a member of the group owning the file. 