### PR TITLE
EB-103: optimise docker image sizes

### DIFF
--- a/docker/data.dockerfile
+++ b/docker/data.dockerfile
@@ -1,18 +1,50 @@
-FROM node:22.2.0
-WORKDIR /swedgene
-VOLUME /swedgene/data
-RUN curl -fsSL https://github.com/samtools/samtools/releases/download/1.20/samtools-1.20.tar.bz2 \
+ARG NODE_VERSION=22.2.0
+
+
+# Stage 1:
+FROM node:${NODE_VERSION} AS build
+ARG SAMTOOLS_VERSION="1.20"
+
+RUN curl -fsSL https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VERSION}/samtools-${SAMTOOLS_VERSION}.tar.bz2 \
     | tar -C /tmp -xjf-  \
-    && cd /tmp/samtools-1.20 && ./configure && make all all-htslib && make install install-htslib \
-    && cd - && rm -rf /tmp/samtools-1.20
+    && cd /tmp/samtools-${SAMTOOLS_VERSION} && ./configure && make all all-htslib && make install install-htslib \
+    && cd - && rm -rf /tmp/samtools-${SAMTOOLS_VERSION}
+
 RUN curl -fsSL --output /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
     && chmod +x /usr/bin/yq
+
 RUN npm install -g @jbrowse/cli
+
+# Stage 2: Slim image to reduce size. 
+FROM node:${NODE_VERSION}-slim 
+
+WORKDIR /swedgene
+VOLUME /swedgene/data
+
+# Install missing dependencies, then clean up non-required files.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    make \
+    libdeflate0 \
+    libcurl4 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy required installs from the build stage 
+COPY --from=build /usr/local/bin/samtools /usr/local/bin/
+COPY --from=build /usr/local/bin/htsfile /usr/local/bin/
+COPY --from=build /usr/local/bin/bgzip /usr/local/bin/
+COPY --from=build /usr/local/bin/tabix /usr/local/bin/
+COPY --from=build /usr/bin/yq /usr/bin/
+COPY --from=build /usr/local/lib/node_modules/@jbrowse /usr/local/lib/node_modules/@jbrowse
+RUN ln -s /usr/local/lib/node_modules/@jbrowse/cli/bin/jbrowse /usr/local/bin/jbrowse
+
 COPY config config
 COPY scripts scripts
 COPY Makefile .
+
 ARG SWG_UID=1000
 ARG SWG_GID=1000
 RUN groupmod -g ${SWG_GID} node && usermod -u ${SWG_UID} -g ${SWG_GID} node
 USER node
+
 CMD ["make", "debug"]

--- a/docker/hugo.dockerfile
+++ b/docker/hugo.dockerfile
@@ -1,21 +1,25 @@
-# Use alpine Linux, download desired version of HUGO and build html files
-FROM alpine:3.19.1 AS build
-RUN apk add --no-cache wget=1.21.4-r0
-ARG HUGO_VERSION="0.123.7"
+# Stage 1: Download HUGO + build static site. 
+FROM alpine:latest AS build
+RUN apk add --no-cache wget
+ARG HUGO_VERSION="0.128.2"
+
 RUN wget --quiet "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz" && \
     tar xzf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
     rm -r hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
     mv hugo /usr/bin && \
     chmod 755 /usr/bin/hugo
+
 WORKDIR /src
 COPY ./hugo/ /src
+
 RUN mkdir /target && \
     hugo -d /target
 
-# Serve the generated html using nginx
-FROM nginxinc/nginx-unprivileged:alpine
+# Stage 2: Serve the generated html using nginx
+FROM nginxinc/nginx-unprivileged:stable-alpine
+
 RUN sed -i '3 a\    absolute_redirect off;' /etc/nginx/conf.d/default.conf && \
     sed -i 's/#error_page  404/error_page  404/' /etc/nginx/conf.d/default.conf
-COPY --from=build /target /usr/share/nginx/html
 
+COPY --from=build /target /usr/share/nginx/html
 EXPOSE 8080

--- a/docker/hugo.dockerfile.dockerignore
+++ b/docker/hugo.dockerfile.dockerignore
@@ -1,0 +1,3 @@
+# This is where the JBrowse data would be stored when testing/running locally
+# This data would instead be attached as a volume to the image though
+hugo/static/data/

--- a/scripts/dockerserve.sh
+++ b/scripts/dockerserve.sh
@@ -16,7 +16,7 @@ CWD="$(pwd)"
 
 docker run -d \
        -p "${SWG_PORT:-$_PORT}":8080 \
-       -v "$CWD/${SWG_DATA_DIR:-$_DATA_DIR}":"$_WWW/static/data" \
+       -v "$CWD/${SWG_DATA_DIR:-$_DATA_DIR}":"$_WWW/data" \
        --name "${SWG_NAME:-$_NAME}" \
        "${SWG_IMAGE:-$_IMAGE}:${SWG_TAG:-$_TAG}" && \
      cat <<EOF


### PR DESCRIPTION
Hi, 

This is an attempt to reduce the sizes of the docker images. 

I think the first 2 commits for the `hugo.dockerfile` are non controversial, but please feel free to disagree of course.  

For the `data.dockerfile` I have manged to reduce the image size to about 1/4 by using a multi-stage build. I tried to use the Node alpine build at first but ran into a lot of missing libraries/dependencies issues that I gave up on that and instead went for the Node slim build instead. 

```
docker images | grep "swg-data-builder"
swg-data-builder                                local-slim      9a4410320927   20 minutes ago      289MB
ghcr.io/scilifelabdatacentre/swg-data-builder   main            28ea12996ea0   23 hours ago        1.19GB
```

I think the `data.dockerfile` is now a bit more complicated and perhaps might be a little more awkward to maintain so I'm marking this as a draft because I'm okay with deciding to keep the data.dockerfile if it feels too awkward. Please say if you have any preferences or opinions there or feel free to make some changes to on this branch 
