### PR TITLE
Enhanced installation recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,4 +167,4 @@ $(filter %.gff.bgz,$(LOCAL_FILES)): %.gff.bgz: %.gff.gz
 $(DOWNLOAD_TARGETS): $(DATA_DIR)/%:| $(DATA_DIR)/.downloads/%
 	@echo "Downloading $@ ..."; \
 	mkdir -p --mode=0755 $(@D) && \
-	curl -# -L --output $@ "$$(< $|)"
+	curl -# -f -L --output $@ "$$(< $|)"

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,14 @@ SHELL=/bin/bash
 # Disable builtin implicit rules
 MAKEFLAGS += -r
 
-CONFIG_DIR=config
-DATA_DIR=data
-INSTALL_DIR=hugo/static
+# SWG_* variables can be set in the process environment
+SWG_CONFIG_DIR ?= config
+SWG_DATA_DIR ?= data
+SWG_INSTALL_DIR ?= hugo/static/data
+
+CONFIG_DIR=$(SWG_CONFIG_DIR)
+DATA_DIR=$(SWG_DATA_DIR)
+INSTALL_DIR=$(SWG_INSTALL_DIR)
 
 # To restrict operations to a subset of species, assign them as a
 # comma-separated list to the SPECIES variable. Example:

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,13 @@ FASTA_INDICES = $(addsuffix .fai,$(filter %.fna.bgz,$(LOCAL_FILES)))
 FASTA_GZINDICES=$(FASTA_INDICES:.fai=.gzi)
 GFF_INDICES = $(addsuffix .tbi,$(filter %.gff.bgz,$(LOCAL_FILES)))
 
+# Files to install
+INSTALLED_FILES = $(patsubst $(DATA_DIR)/%,$(INSTALL_DIR)/%,\
+	$(LOCAL_FILES) \
+	$(FASTA_INDICES) $(FASTA_GZINDICES) \
+	$(GFF_INDICES) \
+	$(JBROWSE_CONFIGS))
+
 # Formatting
 INFO = '\x1b[0;46m'
 RESET = '\x1b[0m'
@@ -59,6 +66,7 @@ debug:
 	$(call log_list, "Compressed local files :", $(LOCAL_FILES))
 	$(call log_list,"FASTA indices :", $(FASTA_INDICES) $(FASTA_GZINDICES))
 	$(call log_list, "GFF indices :", $(GFF_INDICES))
+	$(call log_list, "Files to install:", $(INSTALLED_FILES))
 
 .PHONY: jbrowse-config
 jbrowse-config: $(JBROWSE_CONFIGS);
@@ -98,11 +106,15 @@ compress: $(LOCAL_FILES);
 
 # Copy data and configuration to hugo static folder
 .PHONY: install
-install:
-	@cp --parents -t $(INSTALL_DIR) $(LOCAL_FILES) $(GFF_INDICES) $(FASTA_INDICES) $(JBROWSE_CONFIGS)
+install: $(INSTALLED_FILES);
+
+$(INSTALLED_FILES): $(INSTALL_DIR)/%: $(DATA_DIR)/%
+	@echo "Installing $*"
+	@mkdir -p $(@D)
+	@cp $< $@
 
 # Remove JBrowse data and configuration from hugo static folder
-   .PHONY: uninstall
+.PHONY: uninstall
 uninstall:
 	rm -rf $(INSTALL_DIR)/$(DATA_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ INSTALL_DIR=$(SWG_INSTALL_DIR)
 SPECIES=$(SPECIES:%:{%})
 
 CONFIGS = $(shell find $(CONFIG_DIR)/$(SPECIES) -type f -name 'config.yml')
-JBROWSE_CONFIGS = $(subst $(CONFIG_DIR)/,$(DATA_DIR)/,$(CONFIGS:.yml=.json))
+JBROWSE_CONFIGS = $(patsubst $(CONFIG_DIR)/%,$(DATA_DIR)/%,$(CONFIGS:.yml=.json))
 
 # Defines the DOWNLOAD_TARGETS variable
 include $(DATA_DIR)/targets.mk

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ endef
 
 define log_list	
 @printf $(1)"\n"
-@printf "  - %s\n" $(2)
+@printf "  - %s\n" $(sort $(2))
 endef
 .PHONY: all
 all: build install

--- a/scripts/dockermake.sh
+++ b/scripts/dockermake.sh
@@ -40,8 +40,11 @@ docker_make() {
 	    -e "$dir=${!dir}"
 	)
     done
-    # Don't forget the Makefile
-    _DOCKER_FLAGS+=(-v "$CWD/Makefile:$_DOCKER_WORKDIR/Makefile")
+    # Don't forget the Makefile and script directory
+    _DOCKER_FLAGS+=(
+	-v "$CWD/Makefile:$_DOCKER_WORKDIR/Makefile"
+	-v "$CWD/scripts:$_DOCKER_WORKDIR/scripts"
+    )
     docker run --rm "${_DOCKER_FLAGS[@]}" "${SWG_IMAGE}:${SWG_TAG}" make "$@"
 }
 


### PR DESCRIPTION
- `make` now only installs (_ie_ copies) new files, or files that have changed since last install
-  `make` picks up `SWG_*` variables from the environment
- `scripts/dockermake.sh` leverages the previous point to dynamically build the flags to pass to `docker run` 

Minor bug fixes include:
- tell `curl` to fails when the HTTP responses have a faulty status code (e.g. 404) instead of putting garbage in `.downloads` creating errors further down the line.
- use `patsubst` rather than `subst` to guarantee prefix-substitutions