### PR TITLE
Generalized compression format support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,10 +155,6 @@ $(FASTA_INDICES): %.fai: %
 $(GFF_INDICES): %.tbi: %
 	@$(SHELL) scripts/index_gff.sh $<
 
-
-$(filter %.fna.bgz,$(LOCAL_FILES)): %.fna.bgz: %.fna.gz
-	@$(SHELL) -o pipefail -c "zcat < $< | bgzip > $@"
-
 # Order-only prerequisite to avoid re-downloading everything if data/.downloads
 # directory gets accidentally deleted. Downside: if an upstream file changes,
 # the local outdated copy must be deleted before running `make download`
@@ -167,14 +163,15 @@ $(DOWNLOAD_TARGETS): $(DATA_DIR)/%:| $(DATA_DIR)/.downloads/%
 	mkdir -p --mode=0755 $(@D) && \
 	curl -# -f -L --output $@ "$$(< $|)"
 
-# Sort GFF files prior to compressing, as expected by tabix. Supports
-# both .zip and .gz extensions (and more generally any compression
-# format handled by zcat(1))
+# Recompress downloaded files using bgzip(1).
+#
+# File type specific transformations that need to occur before
+# recompression may be specified in scripts/transform.sh
 #
 # Use a variable to properly escape
 # pattern character. Using \% does not work well with secondary
 # expansion
 _pattern = %
 .SECONDEXPANSION:
-$(filter %.gff.bgz,$(LOCAL_FILES)): %.bgz: $$(filter $$*$$(_pattern),$$(DOWNLOAD_TARGETS))
-	@$(SHELL) -o pipefail -c "zcat < $< | grep -v \"^#\" | sort -t$$'\t' -k1,1 -k4,4n | bgzip > $@"
+$(LOCAL_FILES): %.bgz: $$(filter $$*$$(_pattern),$$(DOWNLOAD_TARGETS))
+	@$(SHELL) -o pipefail -c "zcat -f < $< | ./scripts/filter.sh $(<F) | bgzip > $@"

--- a/Makefile
+++ b/Makefile
@@ -165,8 +165,8 @@ $(DOWNLOAD_TARGETS): $(DATA_DIR)/%:| $(DATA_DIR)/.downloads/%
 
 # Recompress downloaded files using bgzip(1).
 #
-# File type specific transformations that need to occur before
-# recompression may be specified in scripts/transform.sh
+# File-type-specific transformations that need to occur before
+# recompression may be implemented in scripts/filter.sh
 #
 # Use a variable to properly escape
 # pattern character. Using \% does not work well with secondary

--- a/scripts/filter.sh
+++ b/scripts/filter.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Apply filters to stdin prior to compression. The name of the file
+# being streamed is expected as first argument.
+_gff_pattern='\.gff(\.|$)'
+filename="$1"
+if [[ "$filename" =~ $_gff_pattern ]]; then
+    echo "Sorting GFF file $filename" 1>&2
+    grep -v "^#" | sort -t$'\t' -k1 -k4n
+# Default: just forward the stream unmolested
+else
+    cat
+fi
+
+
+

--- a/scripts/generate_jbrowse_config.sh
+++ b/scripts/generate_jbrowse_config.sh
@@ -10,8 +10,8 @@ SPECIES_DATA_DIR="${TARGET%/*}"
 JBROWSE_ARGS=(--force --target="$TARGET")
 
 ensure_local() {
-    # Ensure that we are using a local copy of the file hosted at URL
-    # when it is found in DIR.
+    # Ensure that we use a local copy of the file hosted at URL when
+    # available.
     #
     # Usage :
     #    ensure_local URL FILENAME ARGS_REF
@@ -21,14 +21,18 @@ ensure_local() {
     URL="$1"
     FILENAME="$2"
     local -n args_ref="$3"
+
     # Use explicit filename if provided, otherwise the file part of the URL
     LOCAL_FILE="$(std_extension ${FILENAME:-${URL##*/}})"
 
-    # Remote files are recompressed with bgzip(1) and saved locally
-    # with the .bgz extension.
-    if [[ "$LOCAL_FILE" == *.gz || "$LOCAL_FILE" == *.zip ]]; then
-	LOCAL_FILE="${LOCAL_FILE%.*}.bgz"
-    fi
+    # Downloaded files are recompressed with bgzip(1) and saved
+    # locally with the .bgz extension. The original downloaded file
+    # name always ends with a compression extension that it is safe to
+    # strip off.
+    #
+    # Example: `original.fna.zip` is recompressed as `original.fna.bgz`
+    LOCAL_FILE="${LOCAL_FILE%.*}.bgz"
+
     if ! [[ -e "$SPECIES_DATA_DIR/$LOCAL_FILE" ]]; then
 	args_ref=("$URL")
 	>&2 echo "Using remote file $URL"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -6,15 +6,26 @@ chrom_names() {
     sed -n 's/>\([A-Za-z0-9._]\+\).*/\1/p' "$1"
 }
 
+_zip_extensions=(.gz .zip)
+
+# Mapping between common extensions used for genomic files, and the
+# normalized equivalent we use internally.
+_fasta=fna
+_gff=gff
+declare -A _bio_extensions=(
+    [fasta]=$_fasta
+    [fa]=$_fasta
+    [gff3]=$_gff
+)
 
 std_extension() {
-    for name in "$@";
-    do
-	case $name in
-	    *.fasta*)
-		echo ${name/.fasta/.fna} ;;
-	    *)
-		echo $name ;;
-	esac
+    filename="$1"
+    for ext in "${!_bio_extensions[@]}"; do
+	if [[ "$filename" =~ \."$ext"(\.|$) ]]; then
+	    _std_ext=${_bio_extensions[$ext]}
+	    filename=${filename/".$ext"/".$_std_ext"}
+	    break
+	fi
     done
+    echo "$filename"
 }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -6,7 +6,13 @@ chrom_names() {
     sed -n 's/>\([A-Za-z0-9._]\+\).*/\1/p' "$1"
 }
 
-_zip_extensions=(.gz .zip)
+# Supported compression extensions
+_zip_extensions=(gz zip)
+
+# Sentinel extension we use for uncompressed files. That wy we can
+# internally assume that all files are of the form:
+# NAME.BIO_EXTENSION.ZIP_EXTENSION
+_nozip_extension=nozip
 
 # Mapping between common extensions used for genomic files, and the
 # normalized equivalent we use internally.
@@ -27,5 +33,16 @@ std_extension() {
 	    break
 	fi
     done
+
+    final_ext="${filename##*.}"
+    zipped=0
+    for zip_ext in "${_zip_extensions[@]}"; do
+	[[ "$final_ext" == "$zip_ext" ]] && { zipped=1; break; }
+    done
+
+    if [[ "$zipped" == 0 ]]; then
+	filename="${filename}.${_nozip_extension}"
+    fi
+
     echo "$filename"
 }

--- a/tests/config/zip_extensions/config.yml
+++ b/tests/config/zip_extensions/config.yml
@@ -7,5 +7,7 @@ assembly:
 tracks:
   - name: "Gzipped genes"
     url: "http://fixtures/zip_extensions/genes.gff.gz"
-  - name: "Zipped jeans"
+  - name: "Zipped genes"
     url: "http://fixtures/zip_extensions/other_genes.gff.zip"
+  - name: "Unzipped genes"
+    url: "http://fixtures/zip_extensions/unzipped_genes.gff3"

--- a/tests/fixtures/tiny_herb/genes.gff
+++ b/tests/fixtures/tiny_herb/genes.gff
@@ -1,3 +1,4 @@
 ##gff-version 3
 chr1	      imagination	gene	1	70	.	+	.	ID=gene002
 chr1	      imagination	gene	1	60	.	+	.	ID=gene001
+x

--- a/tests/fixtures/tiny_herb/genes.gff
+++ b/tests/fixtures/tiny_herb/genes.gff
@@ -1,2 +1,3 @@
 ##gff-version 3
+chr1	      imagination	gene	1	70	.	+	.	ID=gene002
 chr1	      imagination	gene	1	60	.	+	.	ID=gene001

--- a/tests/fixtures/zip_extensions/unzipped_genes.gff3
+++ b/tests/fixtures/zip_extensions/unzipped_genes.gff3
@@ -1,0 +1,2 @@
+##gff-version 3
+chr1	      imagination	gene	1	60	.	+	.	ID=gene001


### PR DESCRIPTION
Building on #28, support an extensible set of compression formats for both FASTA and GFF. In particular, no compression at all is allowed. The only limitation is that compression formats be supported by `zcat`.

Highlights:
- The `std_extension` function has been rewritten to ~~use a lot of interesting bash mechanisms~~ be more robust and easily customized
- Files that are not compressed saved with the `.nozip`™ extension
- `bgzip` compression is handled by a single `make` recipe
- `scripts/filter.sh` allows arbitrary pre-gzip transformations to be applied to files

