### PR TITLE
Avoid caching download targets in targets.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ SPECIES=$(SPECIES:%:{%})
 CONFIGS = $(shell find $(CONFIG_DIR)/$(SPECIES) -type f -name 'config.yml')
 JBROWSE_CONFIGS = $(patsubst $(CONFIG_DIR)/%,$(DATA_DIR)/%,$(CONFIGS:.yml=.json))
 
-# Defines the DOWNLOAD_TARGETS variable
-include $(DATA_DIR)/targets.mk
+# Files to download for further processing (typically compressing and indexing)
+DOWNLOAD_TARGETS = $(shell ./scripts/make_download_targets $(CONFIGS))
 
 # Assumes that each download target ends with a compression format
 # extension, for example .zip or .gz
@@ -62,13 +62,12 @@ build: download index-gff index-fasta jbrowse-config
 
 .PHONY: debug
 debug:
-	$(info Restarts : $(MAKE_RESTARTS))
-	$(call log_list, "Target configuration files", $(JBROWSE_CONFIGS))
+	$(call log_list, "JBrowse configuration files :", $(JBROWSE_CONFIGS))
 	$(call log_list, "Files to download :", $(DOWNLOAD_TARGETS))
-	$(call log_list, "Compressed local files :", $(LOCAL_FILES))
-	$(call log_list,"FASTA indices :", $(FASTA_INDICES) $(FASTA_GZINDICES))
+	$(call log_list, "Compressed files :", $(LOCAL_FILES))
+	$(call log_list, "FASTA indices :", $(FASTA_INDICES) $(FASTA_GZINDICES))
 	$(call log_list, "GFF indices :", $(GFF_INDICES))
-	$(call log_list, "Files to install:", $(INSTALLED_FILES))
+	$(call log_list, "Files to install :", $(INSTALLED_FILES))
 
 .PHONY: jbrowse-config
 jbrowse-config: $(JBROWSE_CONFIGS);
@@ -133,13 +132,6 @@ index-gff: $(GFF_INDICES)
 ifneq ($(GFF_INDICES),)
 	$(call log_info,'Indexed GFF files')
 	@printf '  - %s\n' $(GFF_INDICES)
-endif
-
-
-ifeq ($(MAKE_RESTARTS),)
-$(DATA_DIR)/targets.mk: FORCE
-	@CONFIG_DIR=$(CONFIG_DIR) DATA_DIR=$(DATA_DIR) $(SHELL) scripts/make_download_targets $(CONFIGS) > /dev/null
-FORCE:;
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -7,39 +7,40 @@ SWG_CONFIG_DIR ?= config
 SWG_DATA_DIR ?= data
 SWG_INSTALL_DIR ?= hugo/static/data
 
-CONFIG_DIR=$(SWG_CONFIG_DIR)
-DATA_DIR=$(SWG_DATA_DIR)
-INSTALL_DIR=$(SWG_INSTALL_DIR)
+CONFIG_DIR := $(SWG_CONFIG_DIR)
+DATA_DIR := $(SWG_DATA_DIR)
+INSTALL_DIR := $(SWG_INSTALL_DIR)
 
 # To restrict operations to a subset of species, assign them as a
 # comma-separated list to the SPECIES variable. Example:
 #
 #     make SPECIES=linum_tenue,clupea_harengus build
-SPECIES=$(SPECIES:%:{%})
+SPECIES := $(SPECIES:%:{%})
 
-CONFIGS = $(shell find $(CONFIG_DIR)/$(SPECIES) -type f -name 'config.yml')
-JBROWSE_CONFIGS = $(patsubst $(CONFIG_DIR)/%,$(DATA_DIR)/%,$(CONFIGS:.yml=.json))
+CONFIGS := $(shell find $(CONFIG_DIR)/$(SPECIES) -type f -name 'config.yml')
+JBROWSE_CONFIGS := $(patsubst $(CONFIG_DIR)/%,$(DATA_DIR)/%,$(CONFIGS:.yml=.json))
 
 # Files to download for further processing (typically compressing and indexing)
-DOWNLOAD_TARGETS = $(shell ./scripts/make_download_targets $(CONFIGS))
+EXPORT := SWG_DATA_DIR=$(SWG_DATA_DIR) SWG_CONFIG_DIR=$(SWG_CONFIG_DIR)
+DOWNLOAD_TARGETS := $(shell $(EXPORT) ./scripts/make_download_targets $(CONFIGS) 2>/dev/null)
 
 # Assumes that each download target ends with a compression format
 # extension, for example .zip or .gz
-LOCAL_FILES = $(addsuffix .bgz,$(basename $(DOWNLOAD_TARGETS)))
-FASTA_INDICES = $(addsuffix .fai,$(filter %.fna.bgz,$(LOCAL_FILES)))
-FASTA_GZINDICES=$(FASTA_INDICES:.fai=.gzi)
-GFF_INDICES = $(addsuffix .tbi,$(filter %.gff.bgz,$(LOCAL_FILES)))
+LOCAL_FILES := $(addsuffix .bgz,$(basename $(DOWNLOAD_TARGETS)))
+FASTA_INDICES := $(addsuffix .fai,$(filter %.fna.bgz,$(LOCAL_FILES)))
+FASTA_GZINDICES := $(FASTA_INDICES:.fai=.gzi)
+GFF_INDICES := $(addsuffix .tbi,$(filter %.gff.bgz,$(LOCAL_FILES)))
 
 # Files to install
-INSTALLED_FILES = $(patsubst $(DATA_DIR)/%,$(INSTALL_DIR)/%,\
+INSTALLED_FILES := $(patsubst $(DATA_DIR)/%,$(INSTALL_DIR)/%,\
 	$(LOCAL_FILES) \
 	$(FASTA_INDICES) $(FASTA_GZINDICES) \
 	$(GFF_INDICES) \
 	$(JBROWSE_CONFIGS))
 
 # Formatting
-INFO = '\x1b[0;46m'
-RESET = '\x1b[0m'
+INFO := '\x1b[0;46m'
+RESET := '\x1b[0m'
 
 define greet
 $(info $(shell printf '%*s\U1f43f%s\n' 30 '** ' '  **'))
@@ -62,6 +63,7 @@ build: download index-gff index-fasta jbrowse-config
 
 .PHONY: debug
 debug:
+	$(call log_list, "Configuration files :", $(CONFIGS))
 	$(call log_list, "JBrowse configuration files :", $(JBROWSE_CONFIGS))
 	$(call log_list, "Files to download :", $(DOWNLOAD_TARGETS))
 	$(call log_list, "Compressed files :", $(LOCAL_FILES))

--- a/scripts/make_download_targets
+++ b/scripts/make_download_targets
@@ -1,51 +1,112 @@
 #!/bin/bash
-# Generate a makefile initializing the DOWNLOAD_TARGETS variable.
 
-# The value of DOWNLOAD_TARGETS is a space-separated list of files
-# that should be downloaded for local processing. As a side effect,
-# the URL from which target <species>/<filename> should be fectched is
-# stored in the file $DATA_DIR/.downloads/<species>/<file>.
+# List file names to be downloaded for local processing
+#
+# The output is used by make to initialize the DOWNLOAD_TARGETS make
+# variable.
+#
+# As a side effect, the URLs from which targets should be fetche are
+# cached on the filesystem under ${DATA_DIR}/.downloads
+#
+# Arguments:
+#   CONFIG [CONFIG...] : Names of the configuration files to consider
+# Globals:
+#   SWG_CONFIG_DIR
+#   SWG_DATA_DIR
+# Outputs:
+#   Writes target file name one per line to stdout
 
+: "${SWG_DATA_DIR:=data}"
+: "${SWG_CONFIG_DIR:=config}"
+
+# Import the normalize_filename helper
 SRC_DIR="${BASH_SOURCE%/*}"
-source "$SRC_DIR/utils.sh"
+source "${SRC_DIR}/utils.sh"
 
-CACHE_DIR="${DATA_DIR:=data}/.downloads"
-MAKEFILE="$DATA_DIR/targets.mk"
-DOWNLOAD_EXTENSIONS=(".fna" ".gff")
-
-_extract_urls() {
-    # Extract URL and optional file name for the assembly and every
-    # track in configuration files given as arguments
+# List URLs and optional file name for assembly and tracks
+# Arguments:
+#   CONFIG [CONFIG ...] : configuration files to consider
+# Outputs:
+#   Writes lines of semi-colon separated URL;FILENAME pairs to stdout
+list_urls() {
+    # TODO(kwentine): Detect if yq fails before streaming output (return status unreliable)
     yq --no-doc '(.assembly, .tracks[]) | [.url, .fileName // "", fileName] | join(";")' "$@"
 }
 
-_should_download () {
+# Filter targets that need to be downloaded
+# Inputs:
+#   Reads TARGET;URL lines from stdin
+# Outputs:
+#   Writes TARGETs that need to be downloaded to stdout
+filter_download_targets () {
+    local -ar DOWNLOAD_EXTENSIONS=(fna gff)
+    local -a GREP_PATTERNS
     for ext in "${DOWNLOAD_EXTENSIONS[@]}";
     do
-	[[ "$1" == *$ext* ]] && return 0
+	GREP_PATTERNS+=(-e ".${ext}")
     done
-    return 1
+    echo "filter_download_targets: using patterns ${GREP_PATTERNS[*]}" >&2
+    grep "${GREP_PATTERNS[@]}"
 }
 
-mkdir -p "$CACHE_DIR"
+# List file names to download and the URL where they should be fetched
+# Inputs:
+#   Reads URL;FILENAME lines from stdin
+# Globals:
+#   SWG_CONFIG_DIR
+#   SWG_DATA_DIR
+# Outputs:
+#   Writes TARGET;URL lines to stdout
+list_download_targets() {
 
-printf 'DOWNLOAD_TARGETS = ' > "$MAKEFILE"
+    while IFS=";" read -r url target config_file;
+    do
+	config_dir="${config_file%/*}"
+	data_dir="${config_dir/${SWG_CONFIG_DIR}/${SWG_DATA_DIR}}"
+	if [[ -z "$target" ]];
+	then
+	    target=${url##*/}
+	fi
+	target_file="${data_dir}/$(normalize_filename "$target")"
+	printf "%s;%s\n" "${target_file}" "${url}"
+    done
+}
 
-while IFS=";" read -r url target config_file;
-do
-    config_dir=${config_file%/*}
-    data_dir=${config_dir/${CONFIG_DIR}/${DATA_DIR}}
-    if [[ -z "$target" ]];
-    then
-	target=${url##*/}
-    fi
-    target_file="${data_dir}/$(normalize_filename "$target")"
-    _should_download "$target_file" || continue
-    printf '%s' "$target_file " | tee -a "$MAKEFILE"
-    cached="$CACHE_DIR/${target_file/${DATA_DIR}}"
-    if [[ ! -e  "$cached" || ! ( "$(< "$cached")" == "$url" ) ]];
-    then
-	mkdir -p "${cached%/*}"
-	printf '%s' "$url" > "$cached"
-    fi
-done < <(_extract_urls "$@" || exit 1)
+# Create or update files storing the download URLs for targets
+# Inputs:
+#   Reads lines of TARGET;URL pairs from stdin
+# Globals:
+#   SWG_DATA_DIR: data directory prefix
+# Returns:
+#   0, after updating or creating all files storing target URLs
+update_download_cache() {
+    local -r CACHE_DIR="${SWG_DATA_DIR}/.downloads"
+
+    while IFS=';' read -r target url;
+    do
+	cached="${CACHE_DIR}/${target/${SWG_DATA_DIR}}"
+	if [[ ! -e  "$cached" || ! ( "$(< "$cached")" == "${url}" ) ]];
+	then
+	    echo "update_download_cache: set entry '${cached}' to '${url}'" >&2
+	    mkdir -p "${cached%/*}"
+	    printf '%s' "${url}" > "${cached}"
+	else
+	    echo "update_download_cache: entry '${cached}' is up to date" >&2
+	fi
+    done
+}
+
+main() {
+    set -o pipefail
+    list_urls "$@" \
+	| list_download_targets \
+	| filter_download_targets \
+	| tee >(update_download_cache) \
+	| cut -d';' -f1
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]];
+then
+    main "$@"
+fi
+

--- a/scripts/make_download_targets
+++ b/scripts/make_download_targets
@@ -37,7 +37,7 @@ list_urls() {
 # Inputs:
 #   Reads TARGET;URL lines from stdin
 # Outputs:
-#   Writes TARGETs that need to be downloaded to stdout
+#   Forward lines whose TARGET need to be downloaded to stdout
 filter_download_targets () {
     local -ar DOWNLOAD_EXTENSIONS=(fna gff)
     local -a GREP_PATTERNS
@@ -45,7 +45,6 @@ filter_download_targets () {
     do
 	GREP_PATTERNS+=(-e ".${ext}")
     done
-    echo "filter_download_targets: using patterns ${GREP_PATTERNS[*]}" >&2
     grep "${GREP_PATTERNS[@]}"
 }
 

--- a/scripts/make_download_targets
+++ b/scripts/make_download_targets
@@ -2,11 +2,11 @@
 
 # List file names to be downloaded for local processing
 #
-# The output is used by make to initialize the DOWNLOAD_TARGETS make
+# The output is used by make to initialize the DOWNLOAD_TARGETS
 # variable.
 #
-# As a side effect, the URLs from which targets should be fetche are
-# cached on the filesystem under ${DATA_DIR}/.downloads
+# As a side effect, the URLs from which targets should be fetched are
+# cached on the filesystem under ${SWG_DATA_DIR}/.downloads
 #
 # Arguments:
 #   CONFIG [CONFIG...] : Names of the configuration files to consider
@@ -14,7 +14,7 @@
 #   SWG_CONFIG_DIR
 #   SWG_DATA_DIR
 # Outputs:
-#   Writes target file name one per line to stdout
+#   Writes target file names one per line to stdout
 
 : "${SWG_DATA_DIR:=data}"
 : "${SWG_CONFIG_DIR:=config}"
@@ -23,7 +23,7 @@
 SRC_DIR="${BASH_SOURCE%/*}"
 source "${SRC_DIR}/utils.sh"
 
-# List URLs and optional file name for assembly and tracks
+# List URLs and optional file name for every configured assembly and track
 # Arguments:
 #   CONFIG [CONFIG ...] : configuration files to consider
 # Outputs:

--- a/tests/bats/make_download_targets.bats
+++ b/tests/bats/make_download_targets.bats
@@ -1,0 +1,51 @@
+SRC="${BATS_TEST_DIRNAME}"/../../scripts/make_download_targets
+
+@test "list_urls" {
+    . "${SRC}"
+    res=$(list_urls - <<EOF
+assembly:
+  url: foo
+tracks:
+  - url: bar
+    fileName: bar.gff
+EOF
+       )
+    expected=$(printf '%s\n' \
+		      'foo;;-' \
+		      'bar;bar.gff;-')
+    [ "${res}" = "${expected}" ]
+}
+
+@test "list_download_targets" {
+    . "${SRC}"
+    SWG_DATA_DIR=data
+    SWG_CONFIG_DIR=config
+    res=$(list_download_targets <<EOF
+http://figshare.example/1234;foo.gff.gz;config/tiny_herb/config.yaml
+http://figshare.example/bar.fasta;;config/tiny_herb/config.yaml
+EOF
+       )
+
+    expected=$(cat <<EOF
+data/tiny_herb/foo.gff.gz;http://figshare.example/1234
+data/tiny_herb/bar.fna.nozip;http://figshare.example/bar.fasta
+EOF
+	    )
+    [ "${res}" = "${expected}" ]
+}
+
+@test "filter_download_targets" {
+    . "${SRC}"
+    res=$(filter_download_targets <<EOF
+data/tiny_herb/foo.gff.gz;http://figshare.example/1234
+data/tiny_herb/bar.fna.nozip;http://figshare.example/bar.fasta
+data/tiny_herb/baz.txt;http://figshare.example/baz.txt
+EOF
+       )
+    expected=$(cat <<EOF
+data/tiny_herb/foo.gff.gz;http://figshare.example/1234
+data/tiny_herb/bar.fna.nozip;http://figshare.example/bar.fasta
+EOF
+	    )
+    [ "${res}" = "${expected}" ]
+}


### PR DESCRIPTION
No longer resort to the`targets.mk` intermediary makefile to define the `DOWNLOAD_TARGETS` variable. Instead, assign the variable afresh from a shell command every time `make` is invoked. 

This ensures that the `DOWNLOAD_TARGETS` always reflect the state of the configuration when make is invoked, also taking into consideration  `SPECIES=rosa_rosae_rosam` restrictions passed on the command line. 

The `targets.mk` was only rebuilt if a configuration file was added or modified. Not if a configuration was removed. And if `targets.mk` was generated when `make` was called without `SPECIES` argument, it would interfere with a subsequent call made with `SPECIES=foo`. So instead of a more elaborate cache invalidation logic, decided to drop the complexity altogether and incur the microscopic overhead of calling `make_download_targets` on each `make` run.

`make_download_targets` got a nice refactoring in the process and I believe is now more readable.

Finally, an important modification was to use simply expanded variables in the `Makefile` (using the `:=` assignment), making sure the variable definitions are evaluated once and immediately (rather than every time the variable is used)