### PR TITLE
Run hugo development server in docker

### DIFF
--- a/scripts/dockerserve
+++ b/scripts/dockerserve
@@ -1,27 +1,49 @@
 #!/bin/bash
 #
-# Serve hugo site locally in a Docker container
+# Serve hugo site in a Docker container
 #
 # Customize the run by setting the corresponding SWG-prefixed
 # environment variables. For example, to serve on host port 8000 with
-# the `latest` image:
+# the image tagged `latest`:
 #
 # SWG_PORT=8000 SWG_TAG=latest ./scripts/dockerserve.sh
-_IMAGE=ghcr.io/scilifelabdatacentre/swg-hugo-site
-_TAG=local
-_NAME=swedgene-site
-_DATA_DIR=data
-_WWW=/usr/share/nginx/html
-_PORT=8080
+#
+# With the --dev option, run a hugo development server.
 
-CWD="$(pwd)"
+: "${SWG_IMAGE:=ghcr.io/scilifelabdatacentre/swg-hugo-site}"
+: "${SWG_TAG:=local}"
+: "${SWG_NAME:=swedgene-site}"
+: "${SWG_DATA_DIR:=data}"
+: "${SWG_PORT:=8080}"
+: "${SWG_HUGO_IMAGE:=klakegg/hugo}"
+: "${SWG_HUGO_TAG:=latest}"
 
-docker run -d \
-       -p "${SWG_PORT:-$_PORT}":8080 \
-       -v "$CWD/${SWG_DATA_DIR:-$_DATA_DIR}":"$_WWW/data" \
-       --name "${SWG_NAME:-$_NAME}" \
-       "${SWG_IMAGE:-$_IMAGE}:${SWG_TAG:-$_TAG}" && \
-     cat <<EOF
-- Web server is running in container "${SWG_NAME:-$_NAME}".
-- Site can be visited at http://localhost:${SWG_PORT:-$_PORT}
+if [[ -n "${cid:=$(docker ps -qaf name=${SWG_NAME})}" ]]; then
+    cat <<EOF
+Name '${SWG_NAME}' already taken by container ${cid}.
+To remove:
+    docker rm -f ${cid}
+EOF
+    exit 1
+fi
+
+if [[ "$1" == "--dev" ]]; then
+    docker run -d  \
+	   -p "${SWG_PORT}":1313 \
+	   -v "$(pwd)/hugo":"/src" \
+	   --name "${SWG_NAME}" \
+	   "${SWG_HUGO_IMAGE}:${SWG_HUGO_TAG}" serve
+else
+    docker run -d  \
+	   -p "${SWG_PORT}":8080 \
+	   -v "$(pwd)/${SWG_DATA_DIR}":"/usr/share/nginx/html/data" \
+	   --name "${SWG_NAME}" \
+	   "${SWG_IMAGE}:${SWG_TAG}"
+fi && \
+    cat <<EOF
+- Web server is running in container "${SWG_NAME}".
+- Site can be visited at http://localhost:${SWG_PORT}
+
+To shut down:
+    docker rm -f "${SWG_NAME}"
 EOF


### PR DESCRIPTION
The `--dev` flag passed to `scripts/dockerserve` runs `hugo serve` in a docker container, with the working `hugo` directory mounted. It is exposed by default on port `8080`.

This gives a view of the currently checked-out website with the convenience of hot-reloading, without having to install hugo. 