### PR TITLE
Configure assembly display name

### DIFF
--- a/config/clupea_harengus/config.yml
+++ b/config/clupea_harengus/config.yml
@@ -1,6 +1,7 @@
 organism: "Clupea harengus"
 assembly:
   name: Ch_v2.0.2
+  displayName: "Atlantic herring"
   url: "https://hgdownload.soe.ucsc.edu/hubs/GCF/900/700/415/GCF_900700415.2/GCF_900700415.2.2bit"
 tracks:
   - name: "Protein coding genes"

--- a/scripts/generate_jbrowse_config
+++ b/scripts/generate_jbrowse_config
@@ -53,15 +53,15 @@ ensure_local() {
 
 add_assemblies() {
     local -a file_args
-    while IFS=';' read -r url name aliases filename; do
-	args=(--name="$name")
+    while IFS=';' read -r url name displayName aliases filename; do
+	args=(--name="$name" --displayName="${displayName:-name}")
 	if [[ -n "$aliases" ]]; then
 	    args+=(--refNameAliases="$aliases")
 	fi
 	file_args=()
 	ensure_local "$url" "$filename" file_args
 	jbrowse add-assembly "${JBROWSE_ARGS[@]}" "${args[@]}" "${file_args[@]}"
-    done < <(yq '.assembly | [.url, .name, .aliases // "", .fileName // ""] | join(";")' "$1")
+    done < <(yq '.assembly | [.url, .name, .displayName // "", .aliases // "", .fileName // ""] | join(";")' "$1")
 }
 
 add_tracks () {


### PR DESCRIPTION
This PR adds support for a `displayName` key in the `assembly` configuration section. 

For illustrative purposes I just set the property for the herring, unsure about what convention to use (latin names or english equivalents) 

The display name appears in the initial assembly selection drop-down in JBrowse. However, the header of the default browser view unfortunately still uses the assembly `name`.

We will likely need to provide default sessions using #34, where the view display name can be configured.