### PR TITLE
EB-115: Add glossary page

### DIFF
--- a/hugo/assets/glossary.csv
+++ b/hugo/assets/glossary.csv
@@ -1,4 +1,29 @@
 Term (or synonym)|Ontology accession number|Definition
-assembly|[SO:0001248](http://www.sequenceontology.org/browser/current_release/term/SO:0001248)|A region of the genome of known length that is composed by ordering and aligning two or more different regions
-assembly level - chromosome|[FBcv:0003235](https://flybase.org/cgi-bin/cvreport.pl?rel=is_a&id=FBcv:0003235)|There is sequence for one or more chromosomes. This could be a completely sequenced chromosome without gaps or a chromosome containing scaffolds or contigs with gaps between them. There may also be unplaced or unlocalized scaffolds.
-assembly level - scaffold|[FBcv:0003236](https://flybase.org/cgi-bin/cvreport.pl?rel=is_a&id=FBcv:0003236)|Some sequence contigs have been connected across gaps to create scaffolds, but no scaffolds have been placed on chromosomes.
+annotation track|data_3002|Annotation of one particular positional feature on a biomolecular (typically genome) sequence, suitable for import and display in a genome browser.
+assembly|SO:0001248|A region of the genome of known length that is composed by ordering and aligning two or more different regions
+assembly level - chromosome|FBcv:0003235|There is sequence for one or more chromosomes. This could be a completely sequenced chromosome without gaps or a chromosome containing scaffolds or contigs with gaps between them. There may also be unplaced or unlocalized scaffolds.
+assembly level - scaffold|FBcv:0003236|Some sequence contigs have been connected across gaps to create scaffolds, but no scaffolds have been placed on chromosomes.
+contig|SO:0000149|A contiguous sequence derived from sequence assembly. Has no gaps, but may contain N's from unavailable bases.
+contig N50|OBI_0001941|N50 statistic computed for the contigs produced by the assembly process. A contig N50 is calculated by first ordering every contig by length from longest to shortest. Next, starting from the longest contig, the lengths of each contig are summed, until this running sum equals one-half of the total length of all contigs in the assembly. The contig N50 of the assembly is the length of the shortest contig in this list.
+contig N50|GENEPIO_0001633|Contig L50 is the number of contigs equal to or longer than contig N50. The length of the assembly itself is used in the calculation.
+genome assembly|FBcv:0003086|The result of reconstruction of the genome achieved by aligning and merging smaller fragments.
+genome representation - full|FBcv:0003237|The assembly represents the whole genome, though there may still be gaps.
+genome representation - partial|FBcv:0003238|The assembly represents only part of the organism's genome, because only a single chromosome was targeted, coverage is <1, or total length is less than half the average for other assemblies of the same species.
+isoform|SO:0001149|Description of sequence variants produced by alternative splicing, alternative promoter usage, alternative initiation and ribosomal frameshifting.
+mitochondrion|GO:0005739|A semiautonomous, self replicating organelle that occurs in varying numbers, shapes, and sizes in the cytoplasm of virtually all eukaryotic cells. It is notably the site of tissue respiration.
+mitochondrial chromosome|GO:0000262|A chromosome found in the mitochondrion of a eukaryotic cell.
+ncRNA|SO:0000655|An RNA transcript that does not encode for a protein rather the RNA molecule is the gene product.
+ncRNA_gene|SO:0001263|A gene that encodes a non-coding RNA.
+protein_coding|SO:0000010|A gene which, when transcribed, can be translated into a protein.
+pseudogene|SO:0000336|A sequence that closely resembles a known functional gene, at another locus within a genome, that is non-functional as a consequence of (usually several) mutations that prevent either its transcription or translation (or both). In general, pseudogenes result from either reverse transcription of a transcript of their "normal" paralog (SO:0000043) (in which case the pseudogene typically lacks introns and includes a poly(A) tail) or from recombination (SO:0000044) (in which case the pseudogene is typically a tandem duplication of its "normal" paralog).
+reference_genome|SO:0001505|A collection of sequences (often chromosomes) taken as the standard for a given organism and genome assembly.
+reference genome assembly|FBcv:0003087|The result of extensive sequence alignment and merging to produce a genome assembly that serves as the current reference for a particular organism.
+reference genome sequence|FBsv:0001013|A whole genome sequence used as the standard sequence for a species.
+reference sequence|GENO_0000017|A sequence that serves as a standard against which other sequences at the same location are compared.
+RNA-Seq|FBcv:0003068|A quantitative method for mapping transcribed regions, in which complementary DNA fragments are subjected to high-throughput sequencing.
+scaffold|SO:0000148|One or more contigs that have been ordered and oriented using end-read information. Contains gaps that are filled with N's.
+scaffold N50|OBI_0001945|N50 statistic computed for the scaffold produced by the assembly process. The method for computing the value is similar to that of contig N50 but uses scaffold information instead of contig information
+tRNA|SO:0000253|Transfer RNA (tRNA) molecules are approximately 80 nucleotides in length. Their secondary structure includes four short double-helical elements and three loops (D, anti-codon, and T loops). Further hydrogen bonds mediate the characteristic L-shaped molecular structure. Transfer RNAs have two regions of fundamental functional importance: the anti-codon, which is responsible for specific mRNA codon recognition, and the 3' end, to which the tRNA's corresponding amino acid is attached (by aminoacyl-tRNA synthetases). Transfer RNAs cope with the degeneracy of the genetic code in two manners: having more than one tRNA (with a specific anti-codon) for a particular amino acid; and 'wobble' base-pairing, i.e. permitting non-standard base-pairing at the 3rd anti-codon position.
+tRNA_gene|SO:0001272|A noncoding RNA that binds to a specific amino acid to allow that amino acid to be used by the ribosome during translation of RNA.
+transcript|SO:0000673|An RNA synthesized on a DNA or RNA template by an RNA polymerase.
+Transcriptome assembly|operation_3258|Infer a transcriptome sequence by analysis of short sequence reads.

--- a/hugo/assets/glossary.csv
+++ b/hugo/assets/glossary.csv
@@ -1,0 +1,4 @@
+Term (or synonym)|Ontology accession number|Definition
+assembly|[SO:0001248](http://www.sequenceontology.org/browser/current_release/term/SO:0001248)|A region of the genome of known length that is composed by ordering and aligning two or more different regions
+assembly level - chromosome|[FBcv:0003235](https://flybase.org/cgi-bin/cvreport.pl?rel=is_a&id=FBcv:0003235)|There is sequence for one or more chromosomes. This could be a completely sequenced chromosome without gaps or a chromosome containing scaffolds or contigs with gaps between them. There may also be unplaced or unlocalized scaffolds.
+assembly level - scaffold|[FBcv:0003236](https://flybase.org/cgi-bin/cvreport.pl?rel=is_a&id=FBcv:0003236)|Some sequence contigs have been connected across gaps to create scaffolds, but no scaffolds have been placed on chromosomes.

--- a/hugo/content/glossary/_index.md
+++ b/hugo/content/glossary/_index.md
@@ -1,0 +1,5 @@
+---
+title: Glossary
+---
+
+[Content here from **markdown** file describing the glossary page.]

--- a/hugo/content/glossary/_index.md
+++ b/hugo/content/glossary/_index.md
@@ -2,4 +2,10 @@
 title: Glossary
 ---
 
-[Content here from **markdown** file describing the glossary page.]
+## Glossary
+
+There are many specialized terms and concepts used in genomics and bioinformatics. On this page, we have compiled a glossary of some of the scientific terminology used in the Genome Portal to describe data types, methods, and quality metrics.
+
+To facilitate communication, advocate the FAIR principles, and ensure scientific accuracy, the glossary will use terms and definitions from external biological ontologies and controlled vocabularies whenever possible. In particular, we try to use ontologies included in the [Open Biological and Biomedical Ontology (OBO) Foundry](https://obofoundry.org/), which is an open source, non-redudant collection of ontologies.
+
+On the rare occation that a glossary term does not have a definition in any external ontology, we will produce our own definition and include links to the references used to support the definition. If you have any questions or suggestions of new glossary terms, please contact us at [dsn-eb@scilifelab.se](mailto:dsn-eb@scilifelab.se) or through the <a href="/contact">Contact page</a>.

--- a/hugo/layouts/glossary/list.html
+++ b/hugo/layouts/glossary/list.html
@@ -1,0 +1,58 @@
+{{ define "main" }}
+
+<div class="container mt-3">
+    <div class="row">
+        <div class="col scilife-subsection mt-3">
+            {{ .Content }}
+        </div>
+    </div>
+
+    <div class="col scilife-subsection">
+        <div class="table-responsive">
+            {{ with resources.Get "glossary.csv" }}
+                {{ with . | transform.Unmarshal (dict "delimiter" "|" "lazyQuotes" true) }}
+                <table id="glossaryTable" class="table table-hover table-bordered">
+                    <thead class="table-light">
+                        <tr>
+                            {{ range index . 0 }}
+                                <th>{{ . | markdownify }}</th>
+                            {{ end }}
+                        </tr>
+                    </thead>
+
+                    <tbody class="table-responsive">
+                        {{ range after 1 . }}
+                            <tr>
+                            {{ range . }}
+                                <td>{{ . | markdownify }}</td>
+                            {{ end }}
+                            </tr>
+                        {{ end }}
+                    </tbody>
+
+
+                </table>
+                {{ end }}
+            {{ end }}
+        </div>
+    </div>
+
+
+</div>
+
+
+<link href="/Datatables/datatables.min.css" rel="stylesheet">
+<script src="/Datatables/datatables.min.js"></script>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        new DataTable('#glossaryTable', {
+            info: false,
+            ordering: false,
+            paging: false,
+            searching: true
+        });
+    });
+</script>
+
+{{ end }}

--- a/hugo/layouts/glossary/list.html
+++ b/hugo/layouts/glossary/list.html
@@ -23,9 +23,64 @@
                     <tbody class="table-responsive">
                         {{ range after 1 . }}
                             <tr>
-                            {{ range . }}
-                                <td>{{ . | markdownify }}</td>
-                            {{ end }}
+                                {{ $term := index . 0 }}
+                                {{ $accessionCode := index . 1 }}
+                                {{ $definition := index . 2 }}
+
+                                <td>{{ $term | markdownify }}</td>
+
+                                <!-- accession codes altered to contain link to defintion. -->
+                                {{ if strings.HasPrefix $accessionCode "SO:" }}
+                                    <td>
+                                        <a href="http://www.sequenceontology.org/browser/current_release/term/{{$accessionCode}}" target="_blank">
+                                            {{ $accessionCode }}
+                                        </a>
+                                    </td>
+                                {{ else if or (strings.HasPrefix $accessionCode "FBcv:") (strings.HasPrefix $accessionCode "FBsv:") }}
+                                    <td>
+                                        <a href="https://flybase.org/cgi-bin/cvreport.pl?rel=is_a&id={{$accessionCode}}" target="_blank">
+                                            {{ $accessionCode }}
+                                        </a>
+                                    </td>
+                                {{ else if strings.HasPrefix $accessionCode "OBI" }}
+                                    <td>
+                                        <a href="https://ontobee.org/ontology/OBI?iri=http://purl.obolibrary.org/obo/{{$accessionCode}}" target="_blank">
+                                            {{ $accessionCode }}
+                                        </a>
+                                    </td>
+
+                                {{ else if strings.HasPrefix $accessionCode "GENO" }}
+                                    <td>
+                                        <a href="https://ontobee.org/ontology/GENO?iri=http://purl.obolibrary.org/obo/{{$accessionCode}}" target="_blank">
+                                            {{ $accessionCode }}
+                                        </a>
+                                    </td>
+
+                                {{ else if strings.HasPrefix $accessionCode "GENEPIO" }}
+                                    <td>
+                                        <a href="https://ontobee.org/ontology/GENEPIO?iri=http://purl.obolibrary.org/obo/{{$accessionCode}}" target="_blank">
+                                            {{ $accessionCode }}
+                                        </a>
+                                    </td>
+                                {{ else if strings.HasPrefix $accessionCode "GO:" }}
+                                    <td>
+                                        <a href="https://amigo.geneontology.org/amigo/term/{{$accessionCode}}" target="_blank">
+                                            {{ $accessionCode }}
+                                        </a>
+                                    </td>
+
+                                {{ else if or (strings.HasPrefix $accessionCode "operation_") (strings.HasPrefix $accessionCode "data_") }}
+                                    <td>
+                                        <a href="https://bioportal.bioontology.org/ontologies/EDAM?p=classes&conceptid={{$accessionCode}}" target="_blank">
+                                            (EDAM) {{ $accessionCode }}
+                                        </a>
+                                    </td>
+
+                                {{ else }}
+                                    <td>{{ $accessionCode | markdownify }}</td>
+                                {{ end }}
+
+                                <td>{{ $definition | markdownify }}</td>
                             </tr>
                         {{ end }}
                     </tbody>

--- a/hugo/layouts/partials/download_table.html
+++ b/hugo/layouts/partials/download_table.html
@@ -84,9 +84,6 @@
 </div>
 
 
-
-
-
 <caption class="scilife-download-table-caption"> <a href="{{ $staticDirPath }}.csv" target="_blank" >
     <img src="/img/icons/download.svg" alt="Download Icon" class="scilife-icon">
     Download the table contents as a CSV file.
@@ -103,7 +100,7 @@
     Download the refNameAlias text file used in JBrowse to set the aliases for reference sequence names (e.g., to define that "chr1" is an alias for "1").
 </a></caption><br>
 
-<caption class="scilife-download-table-caption"> <a href="#TODO" target="_blank" >
+<caption class="scilife-download-table-caption"> <a href="/glossary" target="_blank" >
     <img src="/img/icons/book_open.svg" alt="Download Icon" class="scilife-icon">
     Open the Glossary (in a new tab).
 </a></caption><br>

--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -11,6 +11,7 @@
                     <li><a href="/add_genome">Add a genome project</a></li>
                     <li><a href="/about">About the portal</a></li>
                     <li><a href="/about/sv">Information på svenska</a></li>
+                    <li><a href="/glossary">Glossary</a></li>
                     <li><a href="/contact">Contact us</a></li>
                     <li><a href="/privacy">Privacy policy</a></li>
                 </ul>


### PR DESCRIPTION
Glossary page for the website created, with links to the glossary in the site footer and at the bottom of each species download table. 

Glossary stored at `hugo/assets/glossary.csv` . The file is a .csv file with "|" as delimiter. Commas, quotes etc.. can therefore be used in the file. Note that to style the text (e.g. italicize a word in the definition), markdown syntax can be used. 

I haven't copied over the summary/descriptive text of the glossary page, but this can be added to the file: `hugo/content/glossary/_index.md` when ready (it will sit above the table). 



