### PR TITLE
EB-128: Add refNameAlias file links to downloads table

### DIFF
--- a/hugo/content/species/linum_trigynum/download.md
+++ b/hugo/content/species/linum_trigynum/download.md
@@ -1,4 +1,5 @@
 ---
+alias_file_url: "https://raw.githubusercontent.com/ScilifelabDataCentre/swedgene/main/scripts/data_stewardship/alias_files_temp_storage/CAMGYJ01.fna.alias"
 # The below parameters were generated automatically and do not need to be changed.
 title: "Download"
 layout: "species_download"

--- a/hugo/layouts/partials/download_table.html
+++ b/hugo/layouts/partials/download_table.html
@@ -88,8 +88,8 @@
       <div class="col-12">
         <caption class="scilife-download-table-caption">
           <a href="{{ $aliasFileURL }}" target="_blank">
-            <img src="/img/icons/book_open.svg" alt="Open in new tab icon" class="scilife-icon">
-            View the refNameAlias text file used in JBrowse to set the aliases for reference sequence names (e.g., to define that "chr1" is an alias for "1").
+            <img src="/img/icons/file.svg" alt="File icon" class="scilife-icon">
+            Open (in a new tab) the refNameAlias text file used in JBrowse to set the aliases for reference sequence names (e.g., to define that "chr1" is an alias for "1").
           </a>
         </caption>
       </div>
@@ -97,7 +97,7 @@
     <div class="col-12">
       <caption class="scilife-download-table-caption">
         <a href="/glossary" target="_blank">
-          <img src="/img/icons/book_open.svg" alt="Open in new tab icon" class="scilife-icon">
+          <img src="/img/icons/book_open.svg" alt="Open book icon" class="scilife-icon">
           Open the Glossary (in a new tab).
         </a>
       </caption>

--- a/hugo/layouts/partials/download_table.html
+++ b/hugo/layouts/partials/download_table.html
@@ -1,6 +1,7 @@
 {{ $tableType := .tableType }}
 {{ $tableData := .tableData }}
 {{ $staticDirPath := .staticDirPath }}
+{{ $aliasFileURL := .aliasFileURL }}
 
 <div class="table-responsive">
     <table id="downloadTable{{ $tableType | title}}" class="table table-hover table-bordered">
@@ -76,32 +77,27 @@
 <div class="row g-1">
     <div class="col-12">
       <caption class="scilife-download-table-caption">
-        <a href="{{ $staticDirPath }}.csv" target="_blank">
-          <img src="/img/icons/download.svg" alt="Download Icon" class="scilife-icon">
-          Download the table contents as a CSV file.
-        </a>
-      </caption>
-    </div>
-    <div class="col-12">
-      <caption class="scilife-download-table-caption">
-        <a href="{{ $staticDirPath }}.json" target="_blank">
+        <a href="{{ $staticDirPath }}.json" download>
           <img src="/img/icons/download.svg" alt="Download Icon" class="scilife-icon">
           Download the table contents as a JSON file.
         </a>
       </caption>
     </div>
-    <div class="col-12">
-      <caption class="scilife-download-table-caption">
-        <a href="#TODO" target="_blank">
-          <img src="/img/icons/download.svg" alt="Download Icon" class="scilife-icon">
-          Download the refNameAlias text file used in JBrowse to set the aliases for reference sequence names (e.g., to define that "chr1" is an alias for "1").
-        </a>
-      </caption>
-    </div>
+
+    {{ if ne $aliasFileURL "" }}
+      <div class="col-12">
+        <caption class="scilife-download-table-caption">
+          <a href="{{ $aliasFileURL }}" target="_blank">
+            <img src="/img/icons/book_open.svg" alt="Open in new tab icon" class="scilife-icon">
+            View the refNameAlias text file used in JBrowse to set the aliases for reference sequence names (e.g., to define that "chr1" is an alias for "1").
+          </a>
+        </caption>
+      </div>
+    {{ end }}
     <div class="col-12">
       <caption class="scilife-download-table-caption">
         <a href="/glossary" target="_blank">
-          <img src="/img/icons/book_open.svg" alt="Download Icon" class="scilife-icon">
+          <img src="/img/icons/book_open.svg" alt="Open in new tab icon" class="scilife-icon">
           Open the Glossary (in a new tab).
         </a>
       </caption>

--- a/hugo/layouts/species/species_download.html
+++ b/hugo/layouts/species/species_download.html
@@ -35,6 +35,13 @@
 
     {{ (resources.Get $tableDataPath | resources.Copy $staticDirFile).Publish }}
 
+
+    {{ $aliasFileURL := "" }}
+    {{ if .Params.alias_file_url }}
+        {{ $aliasFileURL = .Params.alias_file_url }}
+    {{ end }}
+
+
     <div class="row">
         <div class="form-check form-switch scilife-toggle">
             <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckChecked" checked>
@@ -42,11 +49,11 @@
         </div>
 
         <div id="table-container-long">
-            {{ partial "download_table" (dict "tableType" "long" "staticDirPath" $staticDirPath "tableData" $tableData)}}
+            {{ partial "download_table" (dict "tableType" "long" "staticDirPath" $staticDirPath "tableData" $tableData "aliasFileURL" $aliasFileURL )}}
         </div>
 
         <div id="table-container-short">
-            {{ partial "download_table" (dict "tableType" "short" "staticDirPath" $staticDirPath "tableData" $tableData)}}
+            {{ partial "download_table" (dict "tableType" "short" "staticDirPath" $staticDirPath "tableData" $tableData "aliasFileURL" $aliasFileURL )}}
         </div>
     </div>
 

--- a/hugo/static/img/icons/file.svg
+++ b/hugo/static/img/icons/file.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M14 2H6C5.46957 2 4.96086 2.21071 4.58579 2.58579C4.21071 2.96086 4 3.46957 4 4V20C4 20.5304 4.21071 21.0391 4.58579 21.4142C4.96086 21.7893 5.46957 22 6 22H18C18.5304 22 19.0391 21.7893 19.4142 21.4142C19.7893 21.0391 20 20.5304 20 20V8L14 2Z" stroke="#4C979F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M14 2V8H20" stroke="#4C979F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M16 13H8" stroke="#4C979F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M16 17H8" stroke="#4C979F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M10 9H9H8" stroke="#4C979F" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/scripts/templates/download.md
+++ b/scripts/templates/download.md
@@ -1,4 +1,5 @@
 ---
+alias_file_url: "[EDIT]"
 # The below parameters were generated automatically and do not need to be changed.
 title: "Download"
 layout: "species_download"


### PR DESCRIPTION
Hey, 

As discussed over slack, the goal is to add the ability to download the refNameAlias file. 

As each file will be a URL, the current implementation is to just state the URL in the species corresponding `downloads.md` page. I've so far just updated the template file and the Linum tenue `downloads.md` file as you suggested. 

With the current implementation if the parameter is not provided, then the species will not have the option to download the file. 

With regards to UX, I have made it so that clicking on the "download table as a JSON file link", download the file straight away (by using the [download tag](https://www.w3schools.com/tags/att_a_download.asp) ). This can't be done with the alias files as the file is located on an external website, so I changed the labelling to look like this:
![Screenshot from 2024-09-10 10-46-30](https://github.com/user-attachments/assets/ce354573-7812-49be-87b7-3638040ecd51)

If you're happy then I think we can go ahead and add the remaining URLs to the other species and then merge the PR. 

