### PR TITLE
Ensure BED files are tab-delimited, sorted, and include headers 

### DIFF
--- a/scripts/filter
+++ b/scripts/filter
@@ -1,12 +1,32 @@
 #!/bin/bash
 #
 # Apply file-type-specific filters to stdin
-#
+
+
+# Sort BED file
+# Output:
+#   Sorted BED stream with headers preserved.
+sort_bed() {
+    local -r tmp=$(mktemp)
+    cat > "${tmp}"
+    headers=(-e '^browser' -e '^track' -e '^#')
+    grep -E "${headers[@]}" "${tmp}"
+    grep -E -v "${headers[@]}" "${tmp}" | sort -k1,1 -k2,2n
+    rm -f "${tmp}"
+}
+
+# Replace spaces by tabs
+# Output:
+#  Input stream with every whitespace sequence replaced by a
+#  single tab character.
+tabify() {
+    :
+}
+
 # Arguments:
 #   The name of the file being streamed
 # Output:
 #   Writes filtered stream to stdout
-
 main () {
     local -r gff_pattern='\.gff(\.|$)'
     local -r bed_pattern='\.bed(\.|$)'
@@ -18,7 +38,7 @@ main () {
 	fi
     elif [[ "$1" =~ ${bed_pattern} ]]; then
 	echo "Sorting BED file $1" >&2
-	if ! grep -v "^#" | sort -k1,1 -k2,2n; then
+	if ! sort_bed; then
 	    echo "Error filtering contents of BED file: $1" >&2
 	fi
     else
@@ -27,7 +47,10 @@ main () {
     fi
 }
 
-main "$@"
+if [[ ${BASH_SOURCE[0]} == "$0" ]];
+then
+    main "$@"
+fi
 
 
 

--- a/scripts/filter
+++ b/scripts/filter
@@ -20,7 +20,7 @@ sort_bed() {
 #  Input stream with every whitespace sequence replaced by a
 #  single tab character.
 tabify() {
-    :
+    sed -E 's/ +/\t/g'
 }
 
 # Arguments:
@@ -38,7 +38,7 @@ main () {
 	fi
     elif [[ "$1" =~ ${bed_pattern} ]]; then
 	echo "Sorting BED file $1" >&2
-	if ! sort_bed; then
+	if ! tabify | sort_bed; then
 	    echo "Error filtering contents of BED file: $1" >&2
 	fi
     else

--- a/scripts/filter
+++ b/scripts/filter
@@ -20,7 +20,7 @@ sort_bed() {
 #  Input stream with every whitespace sequence replaced by a
 #  single tab character.
 tabify() {
-    sed -E 's/ +/\t/g'
+    sed -E 's/\s+/\t/g'
 }
 
 # Arguments:

--- a/tests/bats/filter.bats
+++ b/tests/bats/filter.bats
@@ -21,8 +21,17 @@ EOF
     [ "${res}" = "${expected}" ]
 }
 
+@test "tabify" {
+    . "${SRC}"
+    res=$(tabify <<EOF
+A 3    4
+EOF
+       )
+    expected=$(printf '%s\t%s\t%s' A 3 4)
+    [ "${res}" = "${expected}" ]
+}
 
-@test "Sort BED file" {
+@test "Sort and tabify BED file" {
     . "${SRC}"
     res=$(main test.bed <<EOF
 # Header
@@ -32,14 +41,6 @@ A 3
 A 2
 EOF
        )
-    expected=$(cat <<EOF
-# Header
-track foo
-browser bar
-A 2
-A 3
-EOF
-       )
+    expected=$(printf '%s\t%s\n' '#' Header track foo browser bar A 2 A 3)
     [ "${res}" = "${expected}" ]
 }
-

--- a/tests/bats/filter.bats
+++ b/tests/bats/filter.bats
@@ -1,0 +1,45 @@
+SRC="${BATS_TEST_DIRNAME}"/../../scripts/filter
+
+@test "sort_bed" {
+    . "${SRC}"
+    res=$(sort_bed <<EOF
+# Header
+track foo
+browser bar
+A 3
+A 2
+EOF
+       )
+    expected=$(cat <<EOF
+# Header
+track foo
+browser bar
+A 2
+A 3
+EOF
+       )
+    [ "${res}" = "${expected}" ]
+}
+
+
+@test "Sort BED file" {
+    . "${SRC}"
+    res=$(main test.bed <<EOF
+# Header
+track foo
+browser bar
+A 3
+A 2
+EOF
+       )
+    expected=$(cat <<EOF
+# Header
+track foo
+browser bar
+A 2
+A 3
+EOF
+       )
+    [ "${res}" = "${expected}" ]
+}
+

--- a/tests/config/tiny_herb/config.yml
+++ b/tests/config/tiny_herb/config.yml
@@ -9,3 +9,5 @@ tracks:
     url: "http://fixtures/tiny_herb/genes.gff.gz"
   - name: "Test track that requires alias in order to display"
     url: "http://fixtures/tiny_herb/data_track_that_requires_alias.gff.gz"
+  - name: "Space-delimited BED file"
+    url: "http://fixtures/tiny_herb/tiny_herb_LG1_repeats_ws_delimited_truncated.bed"


### PR DESCRIPTION
- Ensure BED files are tab-delimited
  - As [discussed](https://scilifelab.atlassian.net/browse/EB-131?focusedCommentId=15732) indiscriminately replace every sequence of spaces by a single tab. Let's see how far that gets us.
- Sort BED files while preserving the header lines 
