### PR TITLE
EB-130: Add meta descriptions for each page. 

### DIFF
--- a/hugo/config.yaml
+++ b/hugo/config.yaml
@@ -1,10 +1,7 @@
-baseURL: "https://swedgene.se/"
+baseURL: "https://genomes.scilifelab.se/"
 languageCode: "en-us"
-title: "Swedish national genome portal, hosted by SciLifeLab"
+title: "Swedish Reference Genome Portal, hosted by SciLifeLab"
 buildFuture: true
-params:
-  title: "Swedish national genome portal, hosted by SciLifeLab"
-  description: "Swedish national genome portal, hosted by SciLifeLab"
 
 markup:
   goldmark:

--- a/hugo/layouts/partials/create_description.html
+++ b/hugo/layouts/partials/create_description.html
@@ -13,7 +13,7 @@
     {{ $description = "Learn more about the Swedish Reference Genome Portal and its mission." }}
 
 {{ else if eq .Title "Information på svenska" }}
-    {{ $description = "Lär dig mer om den Swedish Reference Genome Portal och sin uppdrag." }}
+    {{ $description = "Lär dig mer om Swedish Reference Genome Portal och dess syfte." }}
 
 {{ else if eq .Title "Privacy Policy" }}
     {{ $description = "The privacy policy applicable to the Swedish Reference Genome Portal." }}

--- a/hugo/layouts/partials/create_description.html
+++ b/hugo/layouts/partials/create_description.html
@@ -1,0 +1,59 @@
+<!-- creates the site meta description for each page, good for search engine optimization -->
+
+{{ $description := "" }}
+
+{{ if .IsHome }}
+    {{ $description = "A platform facilitating access and discovery of genome data of non-model eukaryotic species studied in Sweden, hosted by SciLifeLab" }}
+
+<!-- Individ pages -->
+{{ else if eq .Title "Contact" }}
+    {{ $description = "Contact us for more information and support." }}
+
+{{ else if eq .Title "About" }}
+    {{ $description = "Learn more about the Swedish Reference Genome Portal and its mission." }}
+
+{{ else if eq .Title "Information på svenska" }}
+    {{ $description = "Lär dig mer om den Swedish Reference Genome Portal och sin uppdrag." }}
+
+{{ else if eq .Title "Privacy Policy" }}
+    {{ $description = "The privacy policy applicable to the Swedish Reference Genome Portal." }}
+
+{{ else if eq .Title "Glossary" }}
+    {{ $description = "A comprehensive glossary of terms used in the Swedish Reference Genome Portal." }}
+
+{{ else if eq .Title "Contribute" }}
+    {{ $description = "Learn how you, as a researcher affiliated with a Swedish institution, can have data displayed on the Swedish Reference Genome Portal." }}
+
+{{ else if eq .Title "Recommendations for file formats" }}
+    {{ $description =  "Recommendations for the file formats that can be used for displaying data on the Swedish Reference Genome Portal." }}
+
+{{ else if eq .Title "Recommendations of how to make data files publicly available" }}
+    {{ $description =  "We list three recommendations on how to share research data in a manner that follows the FAIR principles and facilitates integration with the Genome Portal." }}
+
+{{ else if eq .Title "Genome Browser" }}
+    {{ $description =  "Browse the genome and its annotations using JBrowse 2." }}
+
+<!-- species section -->
+{{ else if eq .Params.layout "species_intro" }}
+    {{ $title := .Params.title | markdownify | plainify }}
+    {{ $subtitle := .Params.subtitle | markdownify | plainify }}
+    {{ $description =  printf "The Swedish Reference Genome Portals landing page for the species %s, commonly known as: %s."  $title $subtitle }}
+
+{{ else if or (eq .Params.layout "species_assembly") (eq .Params.layout "species_download") }}
+    {{ $parent := .Parent }}
+    {{ $title := $parent.Params.title | markdownify | plainify }}
+
+    {{ if eq .Params.layout "species_assembly" }}
+        {{ $description = printf "Genome assembly statistics obtained from sequencing the %s genome." $title }}
+
+    {{ else if eq .Params.layout "species_download" }}
+        {{ $description = printf "A table of available genomic annotations/data tracks for the species %s with download links provided." $title }}
+
+    {{ end }}
+
+<!-- Just in case anything missed, should not be anything... -->
+{{ else }}
+    {{ $description = "A platform facilitating access and discovery of genome data of non-model eukaryotic species studied in Sweden, hosted by SciLifeLab." }}
+
+{{ end }}
+{{ return $description }}

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -2,14 +2,13 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <!-- Site meta -->
-    <title>
-        {{ with .Params.banner_title }}
-            {{ . }}
-        {{ else }}
-            {{ .Title }}
-        {{ end }}
-        | {{ .Site.Title }}
-    </title>
+    {{ $title := "" }}
+    {{ with .Params.banner_title }}
+        {{ $title = printf "%s" . }}
+    {{ else }}
+        {{ $title = printf "%s" .Title }}
+    {{ end }}
+    <title>{{ printf "%s | %s" $title .Site.Title }}</title>
 
     {{ $description := partial "create_description.html" . }}
     <meta name="description" content="{{ $description }}">

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -10,7 +10,10 @@
         {{ end }}
         | {{ .Site.Title }}
     </title>
-    <meta name="description" content='{{ if .IsHome }}{{ .Param "description" }}{{ else }}{{ .Description }}{{ end }}'>
+
+    {{ $description := partial "create_description.html" . }}
+    <meta name="description" content="{{ $description }}">
+
     <meta http-equiv="content-language" content="en">
     <meta name="theme-color" content="#a7c947">
 


### PR DESCRIPTION
Before this PR only the homepage had a meta tag with a description (found in the <head> of each HTML file). [Lighthouse explains nicely why this is good to have on each page for search engine optimisation](https://developer.chrome.com/docs/lighthouse/seo/meta-description/) 

**The homepage has for example this description:**
`<meta name="description" content="A platform facilitating access and discovery of genome data of non-model eukaryotic species studied in Sweden, hosted by SciLifeLab">`

Now each page is assigned one using the Hugo partial `hugo/layouts/partials/create_description.html`. This includes an automated way to make descriptions for new species so we don't have to worry about that either. 